### PR TITLE
Migrate to Lodash Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "component-type": "^1.2.1",
-    "lodash": "^4.17.4"
+    "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
@@ -38,6 +38,7 @@
     "is-email": "^1.0.0",
     "is-url": "^1.2.2",
     "is-uuid": "^1.0.2",
+    "lodash.pick": "^4.4.0",
     "mocha": "^3.2.0",
     "np": "^2.13.1",
     "uglify-js": "^2.7.0",

--- a/src/superstruct.js
+++ b/src/superstruct.js
@@ -1,5 +1,5 @@
 
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash.clonedeep'
 import typeOf from 'component-type'
 
 import DEFAULT_TYPES from './default-types'

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ import 'babel-polyfill'
 
 import assert from 'assert'
 import fs from 'fs'
-import pick from 'lodash/pick'
+import pick from 'lodash.pick'
 import { basename, extname, resolve } from 'path'
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2562,6 +2562,10 @@ lodash.assign@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -2597,6 +2601,10 @@ lodash.keys@^3.0.0:
 lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
 lodash.pickby@^4.0.0:
   version "4.6.0"


### PR DESCRIPTION
Importing modules from Lodash via `lodash/*` is rarely a clean import. You need to configure babel/webpack heavily and/or use the [babel plugin](https://www.npmjs.com/package/babel-plugin-lodash), which typically still requires extra config.

Any users who wire up this great lib for Module imports will _also_ need to be aware of the full `lodash` import.

It's far better to just use the modular `lodash.*` packages instead. John David Dalton recommends this too! It's more declarative, and is the most reliable way to avoid needless lodash imports.

For example, these changes alone dropped the 95kB minified file to 61kB! 🎉 