### PR TITLE
Rename deprecated script prepublish to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:min": "mkdir -p ./dist && browserify ./src/index.js --transform babelify --standalone Superstruct > ./dist/superstruct.min.js",
     "clean": "rm -rf ./lib ./node_modules",
     "lint": "eslint src/* test/*",
-    "prepublish": "yarn run build",
+    "prepublishOnly": "yarn run build",
     "release": "np",
     "test": "yarn run build:lib && mocha --compilers js:babel-core/register ./test/index.js",
     "watch": "yarn run watch:lib",


### PR DESCRIPTION
Right now, `yarn`/`npm install` end up running the build script:
```
λ yarn
yarn install v1.3.2
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.1.2: The platform "win32" is incompatible with this module.
info "fsevents@1.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
$ yarn run build
yarn run v1.3.2
$ yarn run build:lib && yarn run build:max && yarn run build:min
$ babel ./src --out-dir ./lib
src\default-types.js -> lib\default-types.js
src\index.js -> lib\index.js
src\struct-error.js -> lib\struct-error.js
src\superstruct.js -> lib\superstruct.js
$ mkdir -p ./dist && browserify ./src/index.js --transform babelify --standalone Superstruct > ./dist/superstruct.js
The syntax of the command is incorrect.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
This switches deprecated script `prepublish` to `prepublishOnly`. 

Relevant article - http://blog.lholmquist.org/npm-prepublish-changes/

_Note: I have also opened an issue for the build failure: #12._