### PR TITLE
Use functions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,10 +69,10 @@ const data = {
   } 
 }
 
-Article.assert(data)
+const user = Article(data)
 
-// The `assert()` method throws when the data is invalid, and returns the data otherwise.
-// If you'd rather not throw errors, you can use `validate()` or `test()` instead.
+// This will throw when the data is invalid, and return the data otherwise.
+// If you'd rather not throw, use `Struct.validate()` or `Struct.test()`.
 ```
 
 It recognizes all the native Javascript types out of the box. But you can also define your own custom data types—specific to your application's requirements—by using the `superstruct` export:
@@ -100,7 +100,7 @@ const data = {
   email: 'jane@example.com',
 }
 
-User.assert(data)
+const user = User(data)
 ```
 
 Superstruct supports more complex use cases too like defining list or scalar structs, applying default values, composing structs inside each other, returning errors instead of throwing them, etc. For more information read the full [Documentation](#documentation).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -58,10 +58,10 @@ const User = struct({
 })
 ```
 
-Now we can use our `User` struct to validate the data. The easiest way to do this is to use the `assert()` method, like so:
+Now we can use our `User` struct to validate the data. The easiest way to do this is to just call `User` as a function, like so:
 
 ```
-User.assert(data)
+User(data)
 ```
 
 This will either throw an error if the data is invalid, or return the validated data if the data is valid.
@@ -77,7 +77,7 @@ const data = {
   email: 'jane@example.com',
 }
 
-User.assert(data)
+User(data)
 
 // StructError: 'Expected the `name` property to be of type "string", but it was `false`.' {
 //   code: 'property_invalid',
@@ -90,7 +90,7 @@ User.assert(data)
 
 An error was thrown! That's what we expected.
 
-If you'd rather have the error returned instead of thrown, you can use the struct's `validate()` method. Or, if you'd just like receive a boolean of whether the data is valid or not, use the `test()` method.
+If you'd rather have the error returned instead of thrown, you can use the `Struct.validate()` method. Or, if you'd just like receive a boolean of whether the data is valid or not, use the `Struct.test()` method. Check out the [Reference](./reference.md) for more information.
 
 
 ## Making Values Optional
@@ -111,13 +111,13 @@ That `'boolean?'` with a question mark at the end means that the value can also 
 So now both of these pieces of data would be valid:
 
 ```js
-User.assert({
+User({
   id: 'number',
   name: 'Jane Smith',
   email: 'jane@example.com',
 })
 
-User.assert({
+User({
   id: 'number',
   name: 'Jane Smith',
   email: 'jane@example.com',
@@ -143,7 +143,7 @@ const User = struct({
 })
 ```
 
-To receive the data with the defaults applied, you'll need to store the return value from the `assert()` method. So your validation becomes:
+To receive the data with the defaults applied, you'll need to store the return value from calling `User()`. So your validation becomes:
 
 ```js
 const data = {
@@ -152,7 +152,7 @@ const data = {
   email: 'jane@example.com',
 }
 
-const result = User.assert(data)
+const result = User(data)
 
 // {
 //   id: 'number',
@@ -206,7 +206,7 @@ const data = {
   email: 'jane',
 }
 
-User.assert(data)
+User(data)
 
 // StructError: 'Expected the `email` property to be of type "email", but it was `'jane'`.' {
 //   code: 'property_invalid',
@@ -233,7 +233,7 @@ router.post('/users', ({ request, response }) => {
   const data = request.body
 
   try {
-    User.assert(data)
+    User(data)
   } catch (e) {
     switch (e.code) {
       default: 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,7 +47,7 @@ const Struct = struct({
   is_admin: false 
 })
 
-Struct.assert({
+Struct({
   id: 42,
   name: 'Jane Smith',
 })
@@ -78,7 +78,7 @@ const Struct = struct(...)
 The `superstruct` factory function is used to create your own `struct` function, with a set of custom data types defined. This way you can easily define structs that contain types like `'email'`, `'url'`, or whatever else your application may need.
 
 ### `Struct`
-`Struct`
+`Function(data: Any) => Any`
 
 ```js
 import { struct } from 'superstruct'
@@ -88,12 +88,10 @@ const Struct = struct({
   name: 'string',
 })
 
-Struct.assert(data)
-Struct.validate(data)
-...
+Struct(data)
 ```
 
-`Struct` objects are created by the `struct` factory. They have the following methods:
+`Struct` validator functions are created by the `struct` factory. You can call them directly for the basic use case. But they also have the following method properties:
 
 #### `assert`
 `assert(data: Any) => Any`

--- a/examples/basic-validation.js
+++ b/examples/basic-validation.js
@@ -20,10 +20,9 @@ const data = {
   departments: ['engineering', 'product'],
 }
 
-// Validate the data by calling `assert`. In this case, the data is valid, so
-// it will not throw.
+// Validate the data. In this case, the data is valid, so it won't throw.
 try {
-  User.assert(data)
+  User(data)
   console.log('Valid!')
 } catch (e) {
   throw e

--- a/examples/composing-structs.js
+++ b/examples/composing-structs.js
@@ -28,10 +28,9 @@ const data = {
   }
 }
 
-// Validate the data by calling `validate`. In this case, the data is valid, so
-// it will not throw an error.
+// Validate the data. In this case, the data is valid, so it won't throw.
 try {
-  Article.assert(data)
+  Article(data)
   console.log('Valid!')
 } catch (e) {
   throw e

--- a/examples/custom-errors.js
+++ b/examples/custom-errors.js
@@ -15,11 +15,10 @@ const data = {
   email: 'jane@example.com',
 }
 
-// Validate the data by calling `assert`. In this case the `name` property is
-// invalid, so an error will be thrown that you can catch and customize to your
-// needs.
+// Validate the data. In this case the `name` property is invalid, so an error
+// will be thrown that you can catch and customize to your needs.
 try {
-  User.assert(data)
+  User(data)
   console.log('Valid!')
 } catch (e) {
   switch (e.code) {

--- a/examples/custom-types.js
+++ b/examples/custom-types.js
@@ -29,10 +29,9 @@ const data = {
   website: 'https://jane.example.com',
 }
 
-// Validate the data by calling `assert`. In this case, the data is valid, so
-// it will not throw.
+// Validate the data. In this case, the data is valid, so it won't throw.
 try {
-  User.assert(data)
+  User(data)
   console.log('Valid!')
 } catch (e) {
   throw e

--- a/examples/default-values.js
+++ b/examples/default-values.js
@@ -26,12 +26,12 @@ const data = {
   age: 42,
 }
 
-// Validate the data by calling `assert`, and storing the return value in the
-// `user` variable. Any property that wasn't defined will be set to its default.
+// Validate the data and store the return value in the `user` variable. Any
+// property that wasn't defined will be set to its default.
 let user
 
 try {
-  user = User.assert(data)
+  user = User(data)
   console.log('Valid!', user)
 } catch (e) {
   throw e

--- a/examples/optional-values.js
+++ b/examples/optional-values.js
@@ -16,12 +16,12 @@ const data = {
   age: 42,
 }
 
-// Validate the data by calling `assert`, and storing the return value in the
-// `user` variable. Any property that wasn't defined will be set to its default.
+// Validate the data and store the return value in the `user` variable. Here
+// the `is_admin` property is optional, so it won't throw.
 let user
 
 try {
-  user = User.assert(data)
+  user = User(data)
   console.log('Valid!', user)
 } catch (e) {
   throw e

--- a/examples/returning-errors.js
+++ b/examples/returning-errors.js
@@ -15,8 +15,8 @@ const data = {
   email: 'jane@example.com',
 }
 
-// Validate the data by calling `assert`. In this case the `name` property is
-// invalid, so a `property_invalid` error will be thrown.
+// Validate the data with the `validate` method. In this case the `name`
+// property is invalid, so a `property_invalid` error will be returned.
 const result = User.validate(data)
 
 if (result instanceof StructError) {

--- a/examples/throwing-errors.js
+++ b/examples/throwing-errors.js
@@ -15,10 +15,10 @@ const data = {
   email: 'jane@example.com',
 }
 
-// Validate the data by calling `assert`. In this case the `name` property is
-// invalid, so a `property_invalid` error will be thrown.
+// Validate the data. In this case the `name` property is invalid, so a
+// `property_invalid` error will be thrown.
 try {
-  User.assert(data)
+  User(data)
 } catch (e) {
   throw e
 }

--- a/test/fixtures/custom/optional.js
+++ b/test/fixtures/custom/optional.js
@@ -2,14 +2,14 @@
 import isEmail from 'is-email'
 import { superstruct } from '../../..'
 
-const s = superstruct({
+const struct = superstruct({
   types: {
     email: isEmail
   }
 })
 
-export const struct = s('email?')
+export const Struct = struct('email?')
 
-export const value = undefined
+export const data = undefined
 
 export const output = undefined

--- a/test/fixtures/custom/property-invalid.js
+++ b/test/fixtures/custom/property-invalid.js
@@ -2,17 +2,17 @@
 import isEmail from 'is-email'
 import { superstruct } from '../../..'
 
-const s = superstruct({
+const struct = superstruct({
   types: {
     email: isEmail
   }
 })
 
-export const struct = s({
+export const Struct = struct({
   email: 'email',
 })
 
-export const value = {
+export const data = {
   email: 'invalid'
 }
 

--- a/test/fixtures/custom/property-required.js
+++ b/test/fixtures/custom/property-required.js
@@ -2,17 +2,17 @@
 import isEmail from 'is-email'
 import { superstruct } from '../../..'
 
-const s = superstruct({
+const struct = superstruct({
   types: {
     email: isEmail
   }
 })
 
-export const struct = s({
+export const Struct = struct({
   email: 'email',
 })
 
-export const value = {}
+export const data = {}
 
 export const error = {
   code: 'property_required',

--- a/test/fixtures/custom/valid.js
+++ b/test/fixtures/custom/valid.js
@@ -2,14 +2,14 @@
 import isEmail from 'is-email'
 import { superstruct } from '../../..'
 
-const s = superstruct({
+const struct = superstruct({
   types: {
     email: isEmail
   }
 })
 
-export const struct = s('email')
+export const Struct = struct('email')
 
-export const value = 'sam@example.com'
+export const data = 'sam@example.com'
 
 export const output = 'sam@example.com'

--- a/test/fixtures/custom/value-invalid.js
+++ b/test/fixtures/custom/value-invalid.js
@@ -2,15 +2,15 @@
 import isEmail from 'is-email'
 import { superstruct } from '../../..'
 
-const s = superstruct({
+const struct = superstruct({
   types: {
     email: isEmail
   }
 })
 
-export const struct = s('email')
+export const Struct = struct('email')
 
-export const value = 'invalid'
+export const data = 'invalid'
 
 export const error = {
   code: 'value_invalid',

--- a/test/fixtures/custom/value-required.js
+++ b/test/fixtures/custom/value-required.js
@@ -2,15 +2,15 @@
 import isEmail from 'is-email'
 import { superstruct } from '../../..'
 
-const s = superstruct({
+const struct = superstruct({
   types: {
     email: isEmail
   }
 })
 
-export const struct = s('email')
+export const Struct = struct('email')
 
-export const value = undefined
+export const data = undefined
 
 export const error = {
   code: 'value_required',

--- a/test/fixtures/list-objects/defaults.js
+++ b/test/fixtures/list-objects/defaults.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s([{ id: 'string' }], [{ id: '0' }])
+export const Struct = struct([{ id: 'string' }], [{ id: '0' }])
 
-export const value = undefined
+export const data = undefined
 
 export const output = [{ id: '0' }]

--- a/test/fixtures/list-objects/element-invalid.js
+++ b/test/fixtures/list-objects/element-invalid.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s([{ id: 'string' }])
+export const Struct = struct([{ id: 'string' }])
 
-export const value = [
+export const data = [
   { id: '1' },
   'invalid',
   { id: '3' },

--- a/test/fixtures/list-objects/property-invalid.js
+++ b/test/fixtures/list-objects/property-invalid.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s([{ id: 'string' }])
+export const Struct = struct([{ id: 'string' }])
 
-export const value = [
+export const data = [
   { id: '1' },
   { id: false },
   { id: '3' },

--- a/test/fixtures/list-objects/property-optional.js
+++ b/test/fixtures/list-objects/property-optional.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s([{ id: 'string?' }])
+export const Struct = struct([{ id: 'string?' }])
 
-export const value = [
+export const data = [
   { id: '1' },
   {},
   { id: '3' },

--- a/test/fixtures/list-objects/valid.js
+++ b/test/fixtures/list-objects/valid.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s([{ id: 'string' }])
+export const Struct = struct([{ id: 'string' }])
 
-export const value = [
+export const data = [
   { id: '1' },
   { id: '2' },
   { id: '3' },

--- a/test/fixtures/list-objects/value-invalid.js
+++ b/test/fixtures/list-objects/value-invalid.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s([{ id: 'string' }])
+export const Struct = struct([{ id: 'string' }])
 
-export const value = 'invalid'
+export const data = 'invalid'
 
 export const error = {
   code: 'value_invalid',

--- a/test/fixtures/list-scalars/defaults.js
+++ b/test/fixtures/list-scalars/defaults.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s(['number'], [1])
+export const Struct = struct(['number'], [1])
 
-export const value = undefined
+export const data = undefined
 
 export const output = [1]

--- a/test/fixtures/list-scalars/element-invalid.js
+++ b/test/fixtures/list-scalars/element-invalid.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s(['number'])
+export const Struct = struct(['number'])
 
-export const value = [1, 'invalid', 3]
+export const data = [1, 'invalid', 3]
 
 export const error = {
   code: 'element_invalid',

--- a/test/fixtures/list-scalars/element-optional.js
+++ b/test/fixtures/list-scalars/element-optional.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s(['number?'])
+export const Struct = struct(['number?'])
 
-export const value = [1, undefined, 3]
+export const data = [1, undefined, 3]
 
 export const output = [1, undefined, 3]

--- a/test/fixtures/list-scalars/enum.js
+++ b/test/fixtures/list-scalars/enum.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s(['number|string'])
+export const Struct = struct(['number|string'])
 
-export const value = [1, '2', 3]
+export const data = [1, '2', 3]
 
 export const output = [1, '2', 3]

--- a/test/fixtures/list-scalars/valid.js
+++ b/test/fixtures/list-scalars/valid.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s(['number'])
+export const Struct = struct(['number'])
 
-export const value = [1, 2, 3]
+export const data = [1, 2, 3]
 
 export const output = [1, 2, 3]

--- a/test/fixtures/list-scalars/value-invalid.js
+++ b/test/fixtures/list-scalars/value-invalid.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s(['number'])
+export const Struct = struct(['number'])
 
-export const value = 'invalid'
+export const data = 'invalid'
 
 export const error = {
   code: 'value_invalid',

--- a/test/fixtures/object-lists/element-invalid.js
+++ b/test/fixtures/object-lists/element-invalid.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   title: 'string',
   tags: ['string'],
 })
 
-export const value = {
+export const data = {
   title: 'hello world',
   tags: [false],
 }

--- a/test/fixtures/object-lists/property-invalid.js
+++ b/test/fixtures/object-lists/property-invalid.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   title: 'string',
   tags: ['string'],
 })
 
-export const value = {
+export const data = {
   title: 'hello world',
   tags: 'invalid',
 }

--- a/test/fixtures/object-lists/property-required.js
+++ b/test/fixtures/object-lists/property-required.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   title: 'string',
-  tags: s.required(['string']),
+  tags: struct.required(['string']),
 })
 
-export const value = {
+export const data = {
   title: 'hello world',
 }
 

--- a/test/fixtures/object-lists/valid.js
+++ b/test/fixtures/object-lists/valid.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   title: 'string',
   tags: ['string'],
 })
 
-export const value = {
+export const data = {
   title: 'hello world',
   tags: ['news'],
 }

--- a/test/fixtures/object-objects/defaults.js
+++ b/test/fixtures/object-objects/defaults.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -17,7 +17,7 @@ export const struct = s({
   }
 })
 
-export const value = undefined
+export const data = undefined
 
 export const output = {
   name: 'john',

--- a/test/fixtures/object-objects/nested-property-invalid.js
+++ b/test/fixtures/object-objects/nested-property-invalid.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -10,7 +10,7 @@ export const struct = s({
   }
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
   address: {

--- a/test/fixtures/object-objects/nested-property-optional.js
+++ b/test/fixtures/object-objects/nested-property-optional.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -10,7 +10,7 @@ export const struct = s({
   }
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
   address: {

--- a/test/fixtures/object-objects/nested-property-required.js
+++ b/test/fixtures/object-objects/nested-property-required.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -10,7 +10,7 @@ export const struct = s({
   }
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
   address: {

--- a/test/fixtures/object-objects/nested-property-unknown.js
+++ b/test/fixtures/object-objects/nested-property-unknown.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -10,7 +10,7 @@ export const struct = s({
   }
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
   address: {

--- a/test/fixtures/object-objects/property-invalid.js
+++ b/test/fixtures/object-objects/property-invalid.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -10,7 +10,7 @@ export const struct = s({
   }
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
   address: 'invalid',

--- a/test/fixtures/object-objects/property-optional.js
+++ b/test/fixtures/object-objects/property-optional.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -10,7 +10,7 @@ export const struct = s({
   }
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
 }

--- a/test/fixtures/object-objects/property-required.js
+++ b/test/fixtures/object-objects/property-required.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number',
   address: {
@@ -10,7 +10,7 @@ export const struct = s({
   }
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
 }

--- a/test/fixtures/object-scalars/defaults.js
+++ b/test/fixtures/object-scalars/defaults.js
@@ -1,7 +1,7 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number'
 }, {
@@ -9,7 +9,7 @@ export const struct = s({
   age: 42,
 })
 
-export const value = undefined
+export const data = undefined
 
 export const output = {
   name: 'john',

--- a/test/fixtures/object-scalars/enum.js
+++ b/test/fixtures/object-scalars/enum.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   id: 'string|number',
   zip: 'string|number',
 })
 
-export const value = {
+export const data = {
   id: 1,
   zip: '94203',
 }

--- a/test/fixtures/object-scalars/property-invalid.js
+++ b/test/fixtures/object-scalars/property-invalid.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number'
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 'invalid',
 }

--- a/test/fixtures/object-scalars/property-optional.js
+++ b/test/fixtures/object-scalars/property-optional.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string?',
   age: 'number'
 })
 
-export const value = {
+export const data = {
   age: 42,
 }
 

--- a/test/fixtures/object-scalars/property-required.js
+++ b/test/fixtures/object-scalars/property-required.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number'
 })
 
-export const value = {
+export const data = {
   name: undefined,
   age: 42,
 }

--- a/test/fixtures/object-scalars/property-unknown.js
+++ b/test/fixtures/object-scalars/property-unknown.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number'
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
   unknown: true,

--- a/test/fixtures/object-scalars/valid.js
+++ b/test/fixtures/object-scalars/valid.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number'
 })
 
-export const value = {
+export const data = {
   name: 'john',
   age: 42,
 }

--- a/test/fixtures/object-scalars/value-invalid.js
+++ b/test/fixtures/object-scalars/value-invalid.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s({
+export const Struct = struct({
   name: 'string',
   age: 'number'
 })
 
-export const value = 'invalid'
+export const data = 'invalid'
 
 export const error = {
   code: 'value_invalid',

--- a/test/fixtures/object-structs/defaults.js
+++ b/test/fixtures/object-structs/defaults.js
@@ -1,12 +1,12 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-const address = s({
+const address = struct({
   street: 'string',
   city: 'string',
 })
 
-export const struct = s({
+export const Struct = struct({
   address,
 }, {
   address: {
@@ -15,7 +15,7 @@ export const struct = s({
   }
 })
 
-export const value = undefined
+export const data = undefined
 
 export const output = {
   address: {

--- a/test/fixtures/object-structs/property-invalid.js
+++ b/test/fixtures/object-structs/property-invalid.js
@@ -1,16 +1,16 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-const address = s({
+const address = struct({
   street: 'string?',
   city: 'string',
 })
 
-export const struct = s({
+export const Struct = struct({
   address,
 })
 
-export const value = {
+export const data = {
   address: {
     street: false,
     city: 'springfield',

--- a/test/fixtures/object-structs/property-optional.js
+++ b/test/fixtures/object-structs/property-optional.js
@@ -1,16 +1,16 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-const address = s({
+const address = struct({
   street: 'string?',
   city: 'string',
 })
 
-export const struct = s({
+export const Struct = struct({
   address,
 })
 
-export const value = {
+export const data = {
   address: {
     city: 'springfield',
   }

--- a/test/fixtures/object-structs/property-required.js
+++ b/test/fixtures/object-structs/property-required.js
@@ -1,16 +1,16 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-const address = s({
+const address = struct({
   street: 'string',
   city: 'string',
 })
 
-export const struct = s({
+export const Struct = struct({
   address,
 })
 
-export const value = {
+export const data = {
   address: {
     city: 'springfield',
   }

--- a/test/fixtures/object-structs/property-unknown.js
+++ b/test/fixtures/object-structs/property-unknown.js
@@ -1,16 +1,16 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-const address = s({
+const address = struct({
   street: 'string',
   city: 'string',
 })
 
-export const struct = s({
+export const Struct = struct({
   address,
 })
 
-export const value = {
+export const data = {
   address: {
     street: '123 fake st',
     city: 'springfield',

--- a/test/fixtures/scalar/defaults.js
+++ b/test/fixtures/scalar/defaults.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s('number', 42)
+export const Struct = struct('number', 42)
 
-export const value = undefined
+export const data = undefined
 
 export const output = 42

--- a/test/fixtures/scalar/enum.js
+++ b/test/fixtures/scalar/enum.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s('string|number')
+export const Struct = struct('string|number')
 
-export const value = 42
+export const data = 42
 
 export const output = 42

--- a/test/fixtures/scalar/invalid.js
+++ b/test/fixtures/scalar/invalid.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s('number')
+export const Struct = struct('number')
 
-export const value = 'invalid'
+export const data = 'invalid'
 
 export const error = {
   code: 'value_invalid',

--- a/test/fixtures/scalar/optional.js
+++ b/test/fixtures/scalar/optional.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s('number?')
+export const Struct = struct('number?')
 
-export const value = undefined
+export const data = undefined
 
 export const output = undefined

--- a/test/fixtures/scalar/required.js
+++ b/test/fixtures/scalar/required.js
@@ -1,9 +1,9 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s('number')
+export const Struct = struct('number')
 
-export const value = undefined
+export const data = undefined
 
 export const error = {
   code: 'value_required',

--- a/test/fixtures/scalar/valid.js
+++ b/test/fixtures/scalar/valid.js
@@ -1,8 +1,8 @@
 
-import { struct as s } from '../../..'
+import { struct } from '../../..'
 
-export const struct = s('number')
+export const Struct = struct('number')
 
-export const value = 42
+export const data = 42
 
 export const output = 42

--- a/test/index.js
+++ b/test/index.js
@@ -22,17 +22,17 @@ describe('superstruct', () => {
       for (const test of tests) {
         it(test, async () => {
           const module = require(resolve(testsDir, test))
-          const { struct, value } = module
+          const { Struct, data } = module
 
           if ('output' in module) {
             const expected = module.output
-            const actual = struct(value)
+            const actual = Struct(data)
             assert.deepEqual(actual, expected)
           }
 
           else if ('error' in module) {
             assert.throws(() => {
-              struct(value)
+              Struct(data)
             }, (e) => {
               const expected = module.error
               const actual = pick(e, 'code', 'type', 'key', 'index', 'path', 'value', 'schema')

--- a/test/index.js
+++ b/test/index.js
@@ -26,13 +26,13 @@ describe('superstruct', () => {
 
           if ('output' in module) {
             const expected = module.output
-            const actual = struct.assert(value)
+            const actual = struct(value)
             assert.deepEqual(actual, expected)
           }
 
           else if ('error' in module) {
             assert.throws(() => {
-              struct.assert(value)
+              struct(value)
             }, (e) => {
               const expected = module.error
               const actual = pick(e, 'code', 'type', 'key', 'index', 'path', 'value', 'schema')


### PR DESCRIPTION
This changes the API slightly to make structs functions themselves, instead of class instances. This way the most basic case is actually just:

```js
const User = struct({
  id: 'number',
  name: 'string',
})

const user = User({ id: 1, name: 'Jane Smith' })
```

This brings us even closer inline with the API from Go and other places (which is good IMO):

```go
type User struct {
  id int
  name string
}
```
```go
user := User{id: 1, name: "Jane Smith"}
