### PR TITLE
Refactor struct factory to expose explicit kind functions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,7 +110,7 @@ Superstruct supports more complex use cases too like defining list or scalar str
 
 ### Why?
 
-There are lots of existing validation libraries. Some of them, like [Joi](), [`express-validator`](https://github.com/ctavan/express-validator), [`validator.js`](https://github.com/chriso/validator.js) or [`ajv`](https://github.com/epoberezkin/ajv) are decently popular. But all of them exhibit many issues that lead to hard to maintain codebases...
+There are lots of existing validation libraries. Some of them, like [`joi`](), [`express-validator`](https://github.com/ctavan/express-validator), [`validator.js`](https://github.com/chriso/validator.js), [`yup`](https://github.com/jquense/yup) or [`ajv`](https://github.com/epoberezkin/ajv) are decently popular. But all of them exhibit many issues that lead to hard to maintain codebases...
 
 - **They can't throw errors.** Many validators simply return `true/false` or string errors. Although helpful in the days of callbacks, not using `throw` in modern Javascript makes code much more complex.
 


### PR DESCRIPTION
Right now everything is done with `struct(...)` where the definition can be for any kind of schema, and it will figure it out automatically. This is super useful for keeping things terse. But some kinds are going to require disambiguation. 

So now the `struct(...)` actually is just a smart wrapper around explicit factories for each kind of object. For example:

```js
struct('string')
struct.scalar('string')

struct(['string'])
struct.list(['string'])
```

This paves the way to be able to support things like `struct.dict` more easily.