### PR TITLE
fix throwing errors example with expected values

### DIFF
--- a/examples/throwing-errors.js
+++ b/examples/throwing-errors.js
@@ -23,9 +23,9 @@ try {
   throw e
 }
 
-// StructError: 'Expected a value of type "string" for `name` but received `false`.' {
+// StructError: 'Expected a value of type "string" for `name` but received `true`.' {
 //   data: { ... },
 //   path: ['name'],
-//   value: false,
+//   value: true,
 //   type: 'string',
 // }


### PR DESCRIPTION
The value passed in in the example is actually `true` not `false`. So just a quick correction of the example.