### PR TITLE
Feature: Added promise-type support to default types

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -25,6 +25,7 @@ const TYPES = [
   'null',
   'number',
   'object',
+  'promise',
   'regexp',
   'set',
   'string',


### PR DESCRIPTION
Promises are supported in `kind-of` so wanted to see about adding this.

Tested and confirmed with

```
import { struct } from 'superstruct'

const Struct = ({
     operation: 'promise'
});

const promiseTest = {
    operation: Promise.resolve().then(Promise.resolve())
};

const isValidPromise = Struct(promiseTest);
```