### PR TITLE
Replace uglifyify with rollup plugin

### DIFF
--- a/config/rollup-umd-min.js
+++ b/config/rollup-umd-min.js
@@ -2,10 +2,13 @@
 import babel from 'rollup-plugin-babel'
 import cjs from 'rollup-plugin-commonjs'
 import node from 'rollup-plugin-node-resolve'
+import uglify from 'rollup-plugin-uglify'
+import { minify } from 'uglify-es'
 
 import config from './rollup'
 
 config.output = {
+  file: './umd/superstruct.min.js',
   format: 'umd',
   name: 'Superstruct',
 }
@@ -27,6 +30,7 @@ config.plugins = [
     sourceMap: false,
   }),
   node(),
+  uglify({}, minify)
 ]
 
 export default config

--- a/package.json
+++ b/package.json
@@ -40,15 +40,15 @@
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
-    "uglifyify": "^4.0.5",
-    "watchify": "^3.7.0"
+    "rollup-plugin-uglify": "^2.0.1",
+    "uglify-es": "^3.2.2"
   },
   "scripts": {
     "build": "yarn run build:es && yarn run build:cjs && yarn run build:max && yarn run build:min",
     "build:cjs": "rollup --config ./config/rollup-cjs.js",
     "build:es": "rollup --config ./config/rollup.js",
     "build:max": "rollup --config ./config/rollup-umd.js",
-    "build:min": "NODE_ENV=production rollup --config ./config/rollup-umd-min.js | uglifyjs > ./umd/superstruct.min.js",
+    "build:min": "rollup --config ./config/rollup-umd-min.js",
     "clean": "rm -rf ./lib ./umd ./node_modules",
     "lint": "eslint src/* test/*",
     "prepublish": "yarn run build",


### PR DESCRIPTION
Closes #69

Currently the minify process is done by browserify plugins. This introduces some building errors mentioned in #69. A simpler solution is to remove these plugins and embrace rollup ecosystem. The output file config of UMD bundle is also missing. This PR simply fixes them.

I've tested in following cases:

* Clean `npm install` works fine without error thown.
* `yarn run build` get minified UMD bundle correctly generated.
* `npm run build:min` also works fine.

As a bonus, maybe it's time for us to remove all browserify dependencies. For a pure JS library I haven't found the case to favor it instead of rollup.

Notes:

1. There's some trouble for my network updating `package-lock.json` and `yarn.lock`. Any ideas refreshing them?
2. There's a known issue for uglify.js to minify ES2015. We workaround this with extra config. See also [docs](https://github.com/TrySound/rollup-plugin-uglify#warning) for `rollup-plugin-uglify`.