### PR TITLE
Strip out NODE_ENV in UMD build

### DIFF
--- a/config/rollup-umd.js
+++ b/config/rollup-umd.js
@@ -1,5 +1,10 @@
 
 import config from './rollup'
+import replace from 'rollup-plugin-replace'
+
+config.plugins.push(
+  replace({ 'process.env.NODE_ENV': JSON.stringify('dev') })
+)
 
 config.output = {
   file: './umd/superstruct.js',

--- a/config/rollup-umd.js
+++ b/config/rollup-umd.js
@@ -3,7 +3,7 @@ import config from './rollup'
 import replace from 'rollup-plugin-replace'
 
 config.plugins.push(
-  replace({ 'process.env.NODE_ENV': JSON.stringify('dev') })
+  replace({ 'process.env.NODE_ENV': JSON.stringify('development') })
 )
 
 config.output = {


### PR DESCRIPTION
In #68 following error thrown in JSFiddle: 

```
superstruct.js:275 Uncaught ReferenceError: process is not defined
    at any (VM82 superstruct.js:275)
    at list (VM82 superstruct.js:550)
    at any (VM82 superstruct.js:234)
    at object (VM82 superstruct.js:633)
    at Object.any (VM82 superstruct.js:244)
    at struct (VM82 superstruct.js:1063)
    at window.onload ((index):66)
```

This is due to `process.env.NODE_ENV` is preserved in UMD build, keeping this variable in browser leads to an error.

To my understanding, following strategy is ideal for `NODE_ENV`:

* [x] When used in Node.js server side, `process.env.NODE_ENV` should be kept.
* [x] When used in module bundler, i.e., webpack, `process.env.NODE_ENV` should be kept, leaving user to strip them with things like `DefinePlugin`.
* [ ] When used directly in browser, `process.env.NODE_ENV` should be stripped when we build the lib. It's reasonable to show dev log when using `umd/superstruct.js`, and production warning with `umd/superstruct.min.js`.

So this PR implements the last missing point. With `rollup-plugin-replace` we can easily achieve this without modifying code in `src`.