### PR TITLE
Fix doc catalog href

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,11 +11,11 @@
   + [`enum`](#enum)
   + [`function`](#function)
   + [`intersection`](#intersection)
+  + [`lazy`](#lazy)
   + [`list`](#list)
   + [`object`](#object)
   + [`optional`](#optional)
   + [`scalar`](#scalar)
-  + [`tuple`](#tuple)
   + [`union`](#union)
 - [Types](#types)
   + [Built-in Types](#built-in-types)
@@ -179,6 +179,29 @@ struct.intersection(['string', 'email'])
 
 Intersection structs validate that a value matches all of many structs. Their arguments are any other validate struct schema.
 
+### `lazy`
+
+```js
+const BinaryTree = struct({
+  value: 'any',
+  left: struct.lazy(() => struct.optional(BinaryTree)),
+  right: struct.lazy(() => struct.optional(BinaryTree)),
+})
+```
+```js
+{
+  value: 4,
+  left: {
+    value: 2,
+    left: { value: 1 },
+    right: { value: 3 },
+  },
+  right: { value: 5 },
+}
+```
+
+Lazy structs accepts a function that will return a struct. They are useful to create recursive structs.
+
 ### `list`
 
 ```js
@@ -244,29 +267,6 @@ struct.union(['string', 'number'])
 ```
 
 Union structs validate that a value matches at least one of many structs. Their arguments are any other validate struct schema.
-
-### `lazy`
-
-```js
-const BinaryTree = struct({
-  value: 'any',
-  left: struct.lazy(() => struct.optional(BinaryTree)),
-  right: struct.lazy(() => struct.optional(BinaryTree)),
-})
-```
-```js
-{
-  value: 4,
-  left: {
-    value: 2,
-    left: { value: 1 },
-    right: { value: 3 },
-  },
-  right: { value: 5 },
-}
-```
-
-Lazy structs accepts a function that will return a struct. They are useful to create recursive structs.
 
 ## Types
 


### PR DESCRIPTION
This PR ensures all API under `#structs` links to existing item in alphabetical order.

P.S. There are still some missing `Structs` validator missing in reference manual. Are these kinds designed to be private? I did a quick search and have the following list for missing items:

- [ ] any
- [ ] enums
- [ ] instance
- [ ] interface
- [ ] literal
- [ ] partial
- [ ] tuple
