### PR TITLE
Add static 'format' method on StructError

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -6,6 +6,7 @@
  */
 
 class StructError extends TypeError {
+
   constructor(attrs) {
     super()
     const errors = attrs.errors || []
@@ -25,9 +26,10 @@ class StructError extends TypeError {
   }
 
   static format(attrs) {
-    let path = attrs.path.join('.')
+    const path = attrs.path.join('.')
     return `Expected a value of type \`${attrs.type}\`${path.length ? ` for \`${path}\`` : ''} but received \`${JSON.stringify(attrs.value)}\`.`
   }
+
 }
 
 /**

--- a/src/error.js
+++ b/src/error.js
@@ -6,16 +6,15 @@
  */
 
 class StructError extends TypeError {
-
   constructor(attrs) {
-    const { data, value, type, path, reason, errors = [] } = attrs
-    const message = `Expected a value of type \`${type}\`${path.length ? ` for \`${path.join('.')}\`` : ''} but received \`${JSON.stringify(value)}\`.`
-    super(message)
-    this.data = data
-    this.path = path
-    this.value = value
-    this.type = type
-    this.reason = reason
+    super()
+    const errors = attrs.errors || []
+    this.message = this.constructor.format(attrs)
+    this.data = attrs.data
+    this.path = attrs.path
+    this.value = attrs.value
+    this.reason = attrs.reason
+    this.type = attrs.type
     this.errors = errors
     if (!errors.length) errors.push(this)
     if (Error.captureStackTrace) {
@@ -25,6 +24,10 @@ class StructError extends TypeError {
     }
   }
 
+  static format(attrs) {
+    let path = attrs.path.join('.')
+    return `Expected a value of type \`${attrs.type}\`${path.length ? ` for \`${path}\`` : ''} but received \`${JSON.stringify(attrs.value)}\`.`
+  }
 }
 
 /**


### PR DESCRIPTION
This closes #94 as suggested, but I think I'd prefer my initial approach since this is a bit hacky & still requires importing the entire class object to access the formatter.

It's your call, but ideally, I'd do this:

```js
export function formatError(attrs) {
  // ...same
}

export class StructError extends TypeError {
  constructor(attrs) {
    const msg = formatError(attrs)
    super(msg)
    const errors = attrs.errors || []
    // ...same
  }
}

// ---

import { formatError, StructError } from './error'

export {
  struct,
  superstruct,
  isStruct,
  formatError,
  StructError
}
```

```js
import { formatError } from 'superstruct';
```