### PR TITLE
dict, interface defaults subset

### DIFF
--- a/src/kinds.js
+++ b/src/kinds.js
@@ -313,17 +313,28 @@ function inter(schema, defaults, options) {
     const resolved = resolveDefaults(defaults)
     value = resolved ? { ...resolved, ...value } : value
     const errors = []
+    const ret = value
 
     for (const key in properties) {
-      const v = value[key]
+      let v = value[key]
       const kind = properties[key]
-      const [e] = kind.validate(v)
+
+      if (v === undefined) {
+        const d = defaults && defaults[key]
+        v = resolveDefaults(d, value)
+      }
+
+      const [e, r] = kind.validate(v, value)
 
       if (e) {
         e.path = [key].concat(e.path)
         e.data = value
         errors.push(e)
         continue
+      }
+
+      if (key in value || r !== undefined) {
+        ret[key] = r
       }
     }
 
@@ -333,7 +344,7 @@ function inter(schema, defaults, options) {
       return [first]
     }
 
-    return [undefined, value]
+    return [undefined, ret]
   }
 
   return new Kind(name, type, validate)

--- a/src/kinds.js
+++ b/src/kinds.js
@@ -109,7 +109,9 @@ function dict(schema, defaults, options) {
   const values = any(schema[1], undefined, options)
   const name = 'dict'
   const type = `dict<${keys.type},${values.type}>`
-  const validate = (value = resolveDefaults(defaults)) => {
+  const validate = value => {
+    const resolved = resolveDefaults(defaults)
+    value = resolved ? { ...resolved, ...value } : value
     const [error] = obj.validate(value)
 
     if (error) {
@@ -307,7 +309,9 @@ function inter(schema, defaults, options) {
 
   const name = 'interface'
   const type = `{${ks.join()}}`
-  const validate = (value = resolveDefaults(defaults)) => {
+  const validate = value => {
+    const resolved = resolveDefaults(defaults)
+    value = resolved ? { ...resolved, ...value } : value
     const errors = []
 
     for (const key in properties) {

--- a/test/fixtures/dict-scalars/defaults-subset.js
+++ b/test/fixtures/dict-scalars/defaults-subset.js
@@ -1,0 +1,17 @@
+import { struct } from '../../..'
+
+export const Struct = struct.dict(['string', 'number'], {
+  a: 1,
+  b: 2,
+})
+
+export const data = {
+  a: 3,
+  c: 5,
+}
+
+export const output = {
+  a: 3,
+  b: 2,
+  c: 5,
+}

--- a/test/fixtures/interface/defaults-structs.js
+++ b/test/fixtures/interface/defaults-structs.js
@@ -1,0 +1,31 @@
+import { struct } from '../../..'
+
+const address = struct(
+  {
+    street: 'string',
+    city: 'string',
+  },
+  {
+    street: '123 fake st',
+    city: 'springfield',
+  }
+)
+
+export const Struct = struct.interface({
+  name: 'string',
+  address,
+})
+
+export const data = {
+  name: 'Jane Smith',
+  age: 42,
+}
+
+export const output = {
+  name: 'Jane Smith',
+  address: {
+    street: '123 fake st',
+    city: 'springfield',
+  },
+  age: 42,
+}

--- a/test/fixtures/interface/defaults-subset.js
+++ b/test/fixtures/interface/defaults-subset.js
@@ -1,0 +1,19 @@
+import { struct } from '../../..'
+
+export const Struct = struct.interface(
+  {
+    name: 'string',
+    age: 'number',
+  },
+  {
+    name: 'john',
+    age: 42,
+  }
+)
+
+export const data = { age: 20 }
+
+export const output = {
+  name: 'john',
+  age: 20,
+}

--- a/test/index.js
+++ b/test/index.js
@@ -24,8 +24,8 @@ describe('superstruct', () => {
 
       for (const test of tests) {
         const module = require(resolve(testsDir, test))
-        const { Struct, data, only } = module
-        const run = only ? it.only : it
+        const { Struct, data, only, skip } = module
+        const run = only ? it.only : skip ? it.skip : it
         run(test, () => {
           if ('output' in module) {
             const expected = module.output

--- a/test/index.js
+++ b/test/index.js
@@ -23,10 +23,10 @@ describe('superstruct', () => {
         .map(t => basename(t, extname(t)))
 
       for (const test of tests) {
-        it(test, () => {
-          const module = require(resolve(testsDir, test))
-          const { Struct, data } = module
-
+        const module = require(resolve(testsDir, test))
+        const { Struct, data, only } = module
+        const run = only ? it.only : it
+        run(test, () => {
           if ('output' in module) {
             const expected = module.output
             const actual = Struct(data)


### PR DESCRIPTION
dict and interface defaults subset fix
interfaces composed of structs with their own defaults now resolve those defaults
Also adds .only and .skip support for individual tests (by exports)

I think it closes #104 