### PR TITLE
pass all errors of composed structs for #111

### DIFF
--- a/src/kinds.js
+++ b/src/kinds.js
@@ -127,9 +127,12 @@ function dict(schema, defaults, options) {
       const [e, r] = keys.validate(k)
 
       if (e) {
-        e.path = [k].concat(e.path)
-        e.data = value
-        errors.push(e)
+        const allE = e.errors || [e]
+        allE.forEach(singleE => {
+          singleE.path = [k].concat(singleE.path)
+          singleE.data = value
+          errors.push(singleE)
+        })
         continue
       }
 
@@ -137,9 +140,12 @@ function dict(schema, defaults, options) {
       const [e2, r2] = values.validate(v)
 
       if (e2) {
-        e2.path = [k].concat(e2.path)
-        e2.data = value
-        errors.push(e2)
+        const allE2 = e2.errors || [e2]
+        allE2.forEach(singleE => {
+          singleE.path = [k].concat(singleE.path)
+          singleE.data = value
+          errors.push(singleE)
+        })
         continue
       }
 
@@ -340,9 +346,12 @@ function inter(schema, defaults, options) {
       const [e, r] = kind.validate(v, value)
 
       if (e) {
-        e.path = [key].concat(e.path)
-        e.data = value
-        errors.push(e)
+        const allE = e.errors || [e]
+        allE.forEach(singleE => {
+          singleE.path = [key].concat(singleE.path)
+          singleE.data = value
+          errors.push(singleE)
+        })
         continue
       }
 
@@ -438,9 +447,12 @@ function list(schema, defaults, options) {
       const [e, r] = element.validate(v)
 
       if (e) {
-        e.path = [i].concat(e.path)
-        e.data = value
-        errors.push(e)
+        const allE = e.errors || [e]
+        allE.forEach(singleE => {
+          singleE.path = [i].concat(singleE.path)
+          singleE.data = value
+          errors.push(singleE)
+        })
         continue
       }
 
@@ -543,11 +555,11 @@ function object(schema, defaults, options) {
       const [e, r] = kind.validate(v, value)
 
       if (e) {
-        const allErrors = e.errors || [e]
-        allErrors.forEach(err => {
-          err.path = [key].concat(err.path)
-          err.data = value
-          errors.push(err)
+        const allE = e.errors || [e]
+        allE.forEach(singleE => {
+          singleE.path = [key].concat(singleE.path)
+          singleE.data = value
+          errors.push(singleE)
         })
         return
       }
@@ -636,9 +648,12 @@ function partial(schema, defaults, options) {
       const [e, r] = kind.validate(v, value)
 
       if (e) {
-        e.path = [key].concat(e.path)
-        e.data = value
-        errors.push(e)
+        const allE = e.errors || [e]
+        allE.forEach(singleE => {
+          singleE.path = [key].concat(singleE.path)
+          singleE.data = value
+          errors.push(singleE)
+        })
         continue
       }
 
@@ -756,9 +771,12 @@ function tuple(schema, defaults, options) {
       const [e, r] = kind.validate(v)
 
       if (e) {
-        e.path = [i].concat(e.path)
-        e.data = value
-        errors.push(e)
+        const allE = e.errors || [e]
+        allE.forEach(singleE => {
+          singleE.path = [i].concat(singleE.path)
+          singleE.data = value
+          errors.push(singleE)
+        })
         continue
       }
 

--- a/src/kinds.js
+++ b/src/kinds.js
@@ -543,9 +543,12 @@ function object(schema, defaults, options) {
       const [e, r] = kind.validate(v, value)
 
       if (e) {
-        e.path = [key].concat(e.path)
-        e.data = value
-        errors.push(e)
+        const allErrors = e.errors || [e]
+        allErrors.forEach(err => {
+          err.path = [key].concat(err.path)
+          err.data = value
+          errors.push(err)
+        })
         return
       }
 


### PR DESCRIPTION
#111

Currently only the first error of a sub struct (e.g. list) is included in the parent object struct.

TDB if there are more implications for other struct kinds. Further the testsuite has to be extended for this.

cheers