### PR TITLE
fix to throw out invalid date objects

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -11,7 +11,6 @@ const TYPES = [
   'array',
   'boolean',
   'buffer',
-  'date',
   'error',
   'float32array',
   'float64array',
@@ -51,6 +50,15 @@ const Types = {
 TYPES.forEach(type => {
   Types[type] = value => kindOf(value) === type
 })
+
+/**
+ * Handle the 'date' case specially, to throw out invalid `Date` objects.
+ *
+ * @param {Mixed} value
+ * @return {Boolean}
+ */
+
+Types.date = value => kindOf(value) === 'date' && !isNaN(value)
 
 /**
  * Export.

--- a/test/fixtures/built-ins/date-invalid-date.js
+++ b/test/fixtures/built-ins/date-invalid-date.js
@@ -1,0 +1,14 @@
+import { struct } from '../../..'
+
+const invalid = new Date('invalid')
+
+export const Struct = struct('date')
+
+export const data = invalid
+
+export const error = {
+  path: [],
+  value: invalid,
+  type: 'date',
+  reason: null,
+}

--- a/test/fixtures/built-ins/date-invalid.js
+++ b/test/fixtures/built-ins/date-invalid.js
@@ -1,0 +1,12 @@
+import { struct } from '../../..'
+
+export const Struct = struct('date')
+
+export const data = 'invalid'
+
+export const error = {
+  path: [],
+  value: 'invalid',
+  type: 'date',
+  reason: null,
+}

--- a/test/fixtures/built-ins/date-valid.js
+++ b/test/fixtures/built-ins/date-valid.js
@@ -1,0 +1,7 @@
+import { struct } from '../../..'
+
+export const Struct = struct('date')
+
+export const data = new Date(0)
+
+export const output = new Date(0)

--- a/test/fixtures/built-ins/number-invalid.js
+++ b/test/fixtures/built-ins/number-invalid.js
@@ -1,0 +1,12 @@
+import { struct } from '../../..'
+
+export const Struct = struct('number')
+
+export const data = 'invalid'
+
+export const error = {
+  path: [],
+  value: 'invalid',
+  type: 'number',
+  reason: null,
+}

--- a/test/fixtures/built-ins/number-valid.js
+++ b/test/fixtures/built-ins/number-valid.js
@@ -1,0 +1,7 @@
+import { struct } from '../../..'
+
+export const Struct = struct('number')
+
+export const data = 42
+
+export const output = 42

--- a/test/fixtures/built-ins/string-invalid.js
+++ b/test/fixtures/built-ins/string-invalid.js
@@ -1,0 +1,12 @@
+import { struct } from '../../..'
+
+export const Struct = struct('string')
+
+export const data = 42
+
+export const error = {
+  path: [],
+  value: 42,
+  type: 'string',
+  reason: null,
+}

--- a/test/fixtures/built-ins/string-valid.js
+++ b/test/fixtures/built-ins/string-valid.js
@@ -1,0 +1,7 @@
+import { struct } from '../../..'
+
+export const Struct = struct('string')
+
+export const data = 'valid'
+
+export const output = 'valid'


### PR DESCRIPTION
Fixes #115 by erroring on invalid `Date` objects.