### PR TITLE
Dynamic structs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -259,6 +259,60 @@ const BinaryTree = struct({
 
 `lazy` structs accepts a function that will return a struct. They are useful to create recursive structs.
 
+### `dynamic`
+
+```js
+const map = {
+  TEXT: struct({
+    content: 'string'
+  }),
+  IMAGE: struct({
+    url: 'string'
+  })
+}
+
+const Node = struct({
+  type: struct.enum(['TEXT', 'IMAGE']),
+  value: struct.dynamic((value, parent) => {
+    // Make sure your function never comes back with anything but a struct.
+    return map[parent.type] || struct('undefined')
+  })
+})
+
+const Struct = struct({
+  nodes: [Node]
+})
+```
+
+```js
+{
+  nodes: [
+    {
+      type: 'TEXT',
+      value: {
+        content: 'Hello, world!'
+      }
+    },
+    {
+      type: 'IMAGE',
+      value: {
+        url: 'https://example.com/test.png'
+      }
+    }
+  ]
+}
+```
+
+Dynamic sctructs are functions that return other structs. Use this to dynamically determine the applicable struct for your dataset based on arbitrary and/or deterministic conditions.
+
+The passed function should accept two arguments:
+
+```js
+struct.dynamic((value, parent) => SomeStruct)
+```
+
+Where `value` is the currently validated data and `parent` is the root object of `value`.
+
 ### `list`
 
 ```js

--- a/src/kinds.js
+++ b/src/kinds.js
@@ -408,6 +408,52 @@ function lazy(schema, defaults, options) {
 }
 
 /**
+ * Dynamic.
+ *
+ * @param {Function} createSchema
+ * @param {Any} defaults
+ * @param {Object} options
+ */
+
+function dynamic(createSchema, defaults, options) {
+  if (kindOf(createSchema) !== 'function') {
+    if (process.env.NODE_ENV !== 'production') {
+      throw new Error(
+        `Dynamic structs must be defined as a function, but you passed: ${createSchema}`
+      )
+    } else {
+      throw new Error(`Invalid schema: ${createSchema}`)
+    }
+  }
+
+  const name = 'dynamic'
+  const type = 'dynamic...'
+  const validate = (value = resolveDefaults(defaults), data) => {
+    const schema = createSchema(value, data)
+
+    if (kindOf(schema) !== 'function') {
+      if (process.env.NODE_ENV !== 'production') {
+        throw new Error(
+          `Dynamic structs must return a schema, but you passed: ${schema}`
+        )
+      } else {
+        throw new Error(`Invalid schema: ${schema}`)
+      }
+    }
+
+    const [error, result] = schema.validate(value)
+
+    if (error) {
+      return [error]
+    }
+
+    return [undefined, result]
+  }
+
+  return new Kind(name, type, validate)
+}
+
+/**
  * List.
  *
  * @param {Array} schema
@@ -902,6 +948,7 @@ const Kinds = {
   tuple,
   union,
   intersection,
+  dynamic,
 }
 
 /**

--- a/test/fixtures/dynamic/defaults.js
+++ b/test/fixtures/dynamic/defaults.js
@@ -1,0 +1,9 @@
+import { struct } from '../../..'
+
+const validator = struct('string', 'dynamic')
+
+export const Struct = struct.dynamic(() => validator)
+
+export const data = undefined
+
+export const output = 'dynamic'

--- a/test/fixtures/dynamic/invalid.js
+++ b/test/fixtures/dynamic/invalid.js
@@ -1,0 +1,14 @@
+import { struct } from '../../..'
+
+const validator = struct('string')
+
+export const Struct = struct.dynamic(() => validator)
+
+export const data = 3
+
+export const error = {
+  path: [],
+  value: 3,
+  type: 'string',
+  reason: null,
+}

--- a/test/fixtures/dynamic/nested-list-invalid.js
+++ b/test/fixtures/dynamic/nested-list-invalid.js
@@ -1,0 +1,59 @@
+import { struct } from '../../..'
+
+const Person = struct({
+  age: 'number',
+  nodes: [struct.lazy(() => struct.optional(node))],
+})
+
+const Product = struct({
+  price: 'string',
+})
+
+const map = {
+  PERSON: Person,
+  PRODUCT: Product,
+}
+
+const node = struct({
+  kind: struct.enum(Object.keys(map)),
+  options: struct.dynamic((value, parent) => {
+    return map[parent.kind] || struct('undefined')
+  }),
+})
+
+export const Struct = struct({
+  nodes: [node],
+})
+
+export const data = {
+  nodes: [
+    {
+      kind: 'PERSON',
+      options: {
+        age: 34,
+        nodes: [
+          {
+            kind: 'PERSON',
+            options: {
+              age: 23,
+              nodes: [],
+            },
+          },
+          {
+            kind: 'WHOOPS',
+            options: {
+              price: 'Only $19.99!',
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
+
+export const error = {
+  path: ['nodes', 0, 'options', 'nodes', 1, 'kind'],
+  value: 'WHOOPS',
+  type: '{kind,options} | undefined',
+  reason: undefined,
+}

--- a/test/fixtures/dynamic/nested-list.js
+++ b/test/fixtures/dynamic/nested-list.js
@@ -1,0 +1,54 @@
+import { struct } from '../../..'
+
+const Person = struct({
+  age: 'number',
+  nodes: [struct.lazy(() => struct.optional(node))],
+})
+
+const Product = struct({
+  price: 'string',
+})
+
+const map = {
+  PERSON: Person,
+  PRODUCT: Product,
+}
+
+const node = struct({
+  kind: struct.enum(Object.keys(map)),
+  options: struct.dynamic((value, parent) => {
+    return map[parent.kind] || struct('undefined')
+  }),
+})
+
+export const Struct = struct({
+  nodes: [node],
+})
+
+export const data = {
+  nodes: [
+    {
+      kind: 'PERSON',
+      options: {
+        age: 34,
+        nodes: [
+          {
+            kind: 'PERSON',
+            options: {
+              age: 23,
+              nodes: [],
+            },
+          },
+          {
+            kind: 'PRODUCT',
+            options: {
+              price: 'Only $19.99!',
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
+
+export const output = data

--- a/test/fixtures/dynamic/optional.js
+++ b/test/fixtures/dynamic/optional.js
@@ -1,0 +1,9 @@
+import { struct } from '../../..'
+
+const validator = struct.optional('string')
+
+export const Struct = struct.dynamic(() => validator)
+
+export const data = undefined
+
+export const output = undefined

--- a/test/fixtures/dynamic/reference.js
+++ b/test/fixtures/dynamic/reference.js
@@ -1,0 +1,30 @@
+import { struct } from '../../..'
+
+const User = struct({
+  kind: struct.enum(['USER']),
+  display: 'string',
+})
+
+const Product = struct({
+  kind: struct.enum(['PRODUCT']),
+  price: 'string',
+})
+
+const map = {
+  USER: User,
+  PRODUCT: Product,
+}
+
+export const Struct = struct.dynamic(entity => {
+  return map[entity.kind]
+})
+
+export const data = {
+  kind: 'PRODUCT',
+  price: 'Only $19.99!',
+}
+
+export const output = {
+  kind: 'PRODUCT',
+  price: 'Only $19.99!',
+}

--- a/test/fixtures/dynamic/valid.js
+++ b/test/fixtures/dynamic/valid.js
@@ -1,0 +1,9 @@
+import { struct } from '../../..'
+
+const validator = struct('string')
+
+export const Struct = struct.dynamic(() => validator)
+
+export const data = 'two'
+
+export const output = 'two'

--- a/test/fixtures/lazy/defaults.js
+++ b/test/fixtures/lazy/defaults.js
@@ -1,0 +1,9 @@
+import { struct } from '../../..'
+
+const validator = struct('string', 'lazy')
+
+export const Struct = struct.lazy(() => validator)
+
+export const data = undefined
+
+export const output = 'lazy'

--- a/test/fixtures/lazy/invalid.js
+++ b/test/fixtures/lazy/invalid.js
@@ -1,0 +1,14 @@
+import { struct } from '../../..'
+
+const validator = struct('string')
+
+export const Struct = struct.lazy(() => validator)
+
+export const data = 3
+
+export const error = {
+  path: [],
+  value: 3,
+  type: 'string',
+  reason: null,
+}

--- a/test/fixtures/lazy/optional.js
+++ b/test/fixtures/lazy/optional.js
@@ -1,0 +1,9 @@
+import { struct } from '../../..'
+
+const validator = struct.optional('string')
+
+export const Struct = struct.lazy(() => validator)
+
+export const data = undefined
+
+export const output = undefined

--- a/test/fixtures/lazy/valid.js
+++ b/test/fixtures/lazy/valid.js
@@ -1,0 +1,9 @@
+import { struct } from '../../..'
+
+const validator = struct('string')
+
+export const Struct = struct.lazy(() => validator)
+
+export const data = 'two'
+
+export const output = 'two'


### PR DESCRIPTION
I've come across a use case where I needed to validate many possible structs in a tree-like data structure.  
I've managed to accomplish that by abusing the custom type system:

<details><summary>Code example <b>(click to expand)</b></summary>

```javascript
import {superstruct, struct} from 'superstruct'

const base = struct({'someValue': 'boolean'})
export const Struct = superstruct({
  'types': {
    'base': base.test,
  }
})('base')
```

</details>

While this works as far as validation of the correctness is concerned, I lose the awesome error messages Superstruct generates. This is because the error will contain the fact that only the topmost element in my data tree is incorrect. I'd expect the path to drill down to the lowest level and then work its way up the tree.  

This PR contains a non-breaking change to `src/kinds.js` that makes it possible to fix this behaviour. I've also included tests for the lazy struct in general (which seem to be missing from `test/fixtures`) and the described issue above.  

Thanks for this project, it's saved me (and I'm sure many others) a bunch of hours of rooting around in data! 