### PR TITLE
add failing intersection fixture

### DIFF
--- a/test/fixtures/intersection/valid.js
+++ b/test/fixtures/intersection/valid.js
@@ -1,0 +1,20 @@
+import { struct } from '../../..'
+
+export const Struct = struct.intersection([
+  struct.partial({
+    name: 'string',
+  }),
+  struct.partial({
+    age: 'number',
+  }),
+])
+
+export const data = {
+  name: 'john',
+  age: 42,
+}
+
+export const output = {
+  name: 'john',
+  age: 42,
+}


### PR DESCRIPTION
`intersection` is a critical function for robust schema validation, but it doesn't seem to be working properly. I'm happy to help with whatever issues might be at play here, but wanted to confirm my expectations first.

This PR adds a failing fixture that represents how I understand the `intersection` struct to work in the docs. Below is the test and it's current output:

```js
export const Struct = struct.intersection([
  struct.partial({
    name: 'string',
  }),
  struct.partial({
    age: 'number',
  }),
])

export const data = {
  name: 'john',
  age: 42,
}

export const output = {
  name: 'john',
  age: 42,
}
```

Output:
```
 1) superstruct
       intersection
         valid:
     TypeError: Expected a value of type `{name,...} & {age,...}` for `age` but received `undefined`.
```

It seems to be expecting the entire combined `intersection` struct to validate the value of `age` rather than the entire object, and it's reading the value of `age` as `undefined`.

Am I doing this right?