### PR TITLE
Provides better error messages for nested errors

### DIFF
--- a/src/kinds.js
+++ b/src/kinds.js
@@ -152,13 +152,7 @@ function dict(schema, defaults, options) {
       ret[k] = r2
     }
 
-    if (errors.length) {
-      const first = errors[0]
-      first.errors = errors
-      return [first]
-    }
-
-    return [undefined, ret]
+    return errors.length ? [{ ...errors[0], errors }] : [undefined, ret]
   }
 
   return new Kind(name, type, validate)
@@ -360,13 +354,7 @@ function inter(schema, defaults, options) {
       }
     }
 
-    if (errors.length) {
-      const first = errors[0]
-      first.errors = errors
-      return [first]
-    }
-
-    return [undefined, ret]
+    return errors.length ? [{ ...errors[0], errors }] : [undefined, ret]
   }
 
   return new Kind(name, type, validate)
@@ -505,13 +493,7 @@ function list(schema, defaults, options) {
       ret[i] = r
     }
 
-    if (errors.length) {
-      const first = errors[0]
-      first.errors = errors
-      return [first]
-    }
-
-    return [undefined, ret]
+    return errors.length ? [{ ...errors[0], errors }] : [undefined, ret]
   }
 
   return new Kind(name, type, validate)
@@ -615,13 +597,7 @@ function object(schema, defaults, options) {
       }
     })
 
-    if (errors.length) {
-      const first = errors[0]
-      first.errors = errors
-      return [first]
-    }
-
-    return [undefined, ret]
+    return errors.length ? [{ ...errors[0], errors }] : [undefined, ret]
   }
 
   return new Kind(name, type, validate)
@@ -708,13 +684,7 @@ function partial(schema, defaults, options) {
       }
     }
 
-    if (errors.length) {
-      const first = errors[0]
-      first.errors = errors
-      return [first]
-    }
-
-    return [undefined, ret]
+    return errors.length ? [{ ...errors[0], errors }] : [undefined, ret]
   }
 
   return new Kind(name, type, validate)
@@ -829,13 +799,7 @@ function tuple(schema, defaults, options) {
       ret[i] = r
     }
 
-    if (errors.length) {
-      const first = errors[0]
-      first.errors = errors
-      return [first]
-    }
-
-    return [undefined, ret]
+    return errors.length ? [{ ...errors[0], errors }] : [undefined, ret]
   }
 
   return new Kind(name, type, validate)

--- a/test/fixtures/dynamic/nested-list-invalid.js
+++ b/test/fixtures/dynamic/nested-list-invalid.js
@@ -54,6 +54,6 @@ export const data = {
 export const error = {
   path: ['nodes', 0, 'options', 'nodes', 1, 'kind'],
   value: 'WHOOPS',
-  type: '{kind,options} | undefined',
+  type: '"PERSON" | "PRODUCT"',
   reason: undefined,
 }


### PR DESCRIPTION
Previously nested errors messages would describe the parent type of a nested error, rather than the type of the field that actually failed to validate.  This isn't exactly inaccurate (a parent is invalid if a child is invalid), but not very helpful for identifying errors in these circumstances.  

Example previously:

> Error message: "Expected a value of type `[{SectionType1,SectionType2,SectionType3} | undefined | null] | undefined | null` for `sections.0.blockInputTypeA.0.notes` but received `undefined`."

The equivalent error now reads:

> Error message: "Expected a value of type `String` for `sections.0.blockInputTypeA.0.notes` but received `undefined`."

Which more accurately reports the actual field that failed to validate.