### PR TITLE
Validate that an interface is an object before checking it's properties

### DIFF
--- a/src/kinds.js
+++ b/src/kinds.js
@@ -310,6 +310,7 @@ function inter(schema, defaults, options) {
     }
   }
 
+  const obj = scalar('object', undefined, options)
   const ks = []
   const properties = {}
 
@@ -323,6 +324,13 @@ function inter(schema, defaults, options) {
   const name = 'interface'
   const type = `{${ks.join()}}`
   const validate = (value = resolveDefaults(defaults)) => {
+    const [error] = obj.validate(value)
+
+    if (error) {
+      error.type = type
+      return [error]
+    }
+
     const errors = []
     const ret = value
 

--- a/test/fixtures/interface/invalid-nested.js
+++ b/test/fixtures/interface/invalid-nested.js
@@ -1,0 +1,20 @@
+import { struct } from '../../..'
+
+export const Struct = struct({
+  id: 'number',
+  person: struct.interface({
+    name: 'string',
+    age: 'number',
+  }),
+})
+
+export const data = {
+  id: 1,
+}
+
+export const error = {
+  path: ['person'],
+  value: undefined,
+  type: '{name,age}',
+  reason: null,
+}

--- a/test/fixtures/interface/invalid.js
+++ b/test/fixtures/interface/invalid.js
@@ -8,8 +8,8 @@ export const Struct = struct.interface({
 export const data = 'invalid'
 
 export const error = {
-  path: ['name'],
-  value: undefined,
-  type: 'string',
+  path: [],
+  value: 'invalid',
+  type: '{name,age}',
   reason: null,
 }

--- a/test/fixtures/interface/valid-object-instance.js
+++ b/test/fixtures/interface/valid-object-instance.js
@@ -1,0 +1,20 @@
+import { struct } from '../../..'
+
+class Person {
+  constructor(name, age) {
+    this.name = name
+    this.age = age
+  }
+}
+
+export const Struct = struct.interface({
+  name: 'string',
+  age: 'number',
+})
+
+export const data = new Person('john', 42)
+
+export const output = {
+  name: 'john',
+  age: 42,
+}


### PR DESCRIPTION
Added a validation to check if a `interface` is an object before checking it's properties.
This validation was taken from `partial`.

Test fixture added.
One fixture had to be changed because it's expected error was wrong.

Fixes #119