### PR TITLE
Introduce a custom error object option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,7 +104,7 @@ const user = User(data)
 
 Superstruct supports more complex use cases too like defining list or scalar structs, applying default values, composing structs inside each other, returning errors instead of throwing them, etc. For more information read the full [Documentation](#documentation).
 
-You could also define a custom error object derived from a TypeError by using the `superstruct` export. Maybe you do not want to expose sensitive user data in the logs for example.
+You could also define a [custom error](./examples/custom-errors.js) object derived from a TypeError by using the `superstruct` factory. Maybe you do not want to expose sensitive user data in the logs for example. 
 
 ```js
 import { superstruct } from 'superstruct'
@@ -178,6 +178,7 @@ Superstruct's API is very flexible, allowing it to be used for a variety of use 
 * [Composing Structs](./examples/composing-structs.js)
 * [Throwing Errors](./examples/throwing-errors.js)
 * [Returning Errors](./examples/returning-errors.js)
+* [Handling Errors](./examples/handling-errors.js)
 * [Custom Errors](./examples/custom-errors.js)
 
 <br/>

--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,17 @@ const user = User(data)
 
 Superstruct supports more complex use cases too like defining list or scalar structs, applying default values, composing structs inside each other, returning errors instead of throwing them, etc. For more information read the full [Documentation](#documentation).
 
+You could also define a custom error object derived from a TypeError by using the `superstruct` export. Maybe you do not want to expose sensitive user data in the logs for example.
+
+```js
+import { superstruct } from 'superstruct'
+import CustomError from './somewhere/CustomError'
+
+const struct = superstruct({
+  error: CustomError,
+})
+```
+
 <br/>
 
 ### Why?

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -511,7 +511,7 @@ These custom types are simple functions that return `true/false` or a string den
 
 ## Errors
 
-Superstruct throws detailed errors when data is invalid, so that you can build extremely precise errors of your own to give your end users the best possible experience.
+Superstruct per default throws detailed errors when data is invalid, so that you can build extremely precise errors of your own to give your end users the best possible experience.
 
 ### Error Properties
 

--- a/examples/handling-errors.js
+++ b/examples/handling-errors.js
@@ -1,0 +1,47 @@
+import { struct } from 'superstruct'
+
+// Define a struct to validate with.
+const User = struct({
+  id: 'number',
+  name: 'string',
+  email: 'string',
+})
+
+// Define data to be validated.
+const data = {
+  id: 1,
+  name: true,
+  email: 'jane@example.com',
+}
+
+// Validate the data. In this case the `name` property is invalid, so an error
+// will be thrown that you can catch and customize to your needs.
+try {
+  User(data)
+  console.log('Valid!')
+} catch (e) {
+  const { path, value, type } = e
+  const key = path[0]
+
+  if (value === undefined) {
+    const error = new Error(`user_${key}_required`)
+    error.attribute = key
+    throw error
+  }
+
+  if (type === undefined) {
+    const error = new Error(`user_attribute_unknown`)
+    error.attribute = key
+    throw error
+  }
+
+  const error = new Error(`user_${key}_invalid`)
+  error.attribute = key
+  error.value = value
+  throw error
+}
+
+// Error: 'user_name_invalid' {
+//   attribute: 'name',
+//   value: false,
+// }

--- a/src/error.js
+++ b/src/error.js
@@ -5,19 +5,13 @@
  */
 
 class StructError extends TypeError {
-  static format(attrs) {
-    const { type, path, value } = attrs
+  constructor({ data, path, value, reason, type, errors = [] }) {
     const message = `Expected a value of type \`${type}\`${
       path.length ? ` for \`${path.join('.')}\`` : ''
     } but received \`${JSON.stringify(value)}\`.`
-    return message
-  }
 
-  constructor(attrs) {
-    const message = StructError.format(attrs)
     super(message)
 
-    const { data, path, value, reason, type, errors = [] } = attrs
     this.data = data
     this.path = path
     this.value = value

--- a/src/superstruct.js
+++ b/src/superstruct.js
@@ -1,5 +1,5 @@
 import Kinds from './kinds'
-import StructError from './error'
+import DefaultStructError from './error'
 import Types from './types'
 import { isStruct } from './utils'
 import { IS_STRUCT, KIND } from './constants'
@@ -16,6 +16,8 @@ function superstruct(config = {}) {
     ...Types,
     ...(config.types || {}),
   }
+
+  const StructError = config.error || DefaultStructError
 
   /**
    * Create a `kind` struct with `schema`, `defaults` and `options`.

--- a/test/fixtures/custom-error/custom-error.js
+++ b/test/fixtures/custom-error/custom-error.js
@@ -1,19 +1,13 @@
 import { superstruct } from '../../..'
 
 class StructErrorWithoutValue extends TypeError {
-  static format(attrs) {
-    const { type, path } = attrs
+  constructor({ path, reason, type, errors = [] }) {
     const message = `Expected a value of type \`${type}\`${
       path.length ? ` for \`${path.join('.')}\`` : ''
     }.`
-    return message
-  }
 
-  constructor(attrs) {
-    const message = StructErrorWithoutValue.format(attrs)
     super(message)
 
-    const { path, reason, type, errors = [] } = attrs
     this.path = path
     this.reason = reason
     this.type = type

--- a/test/fixtures/custom-error/custom-error.js
+++ b/test/fixtures/custom-error/custom-error.js
@@ -1,40 +1,42 @@
 import { superstruct } from '../../..'
 
 class StructErrorWithoutValue extends TypeError {
-    static format(attrs) {
-      const { type, path } = attrs;
-      const message = `Expected a value of type \`${type}\`${path.length ? ` for \`${path.join('.')}\`` : ''}.`;
-      return message;
-    }
-  
-    constructor(attrs) {
-      const message = StructErrorWithoutValue.format(attrs);
-      super(message);
-  
-      const { path, reason, type, errors = [] } = attrs;
-      this.path = path;
-      this.reason = reason;
-      this.type = type;
-      this.errors = errors.map(error => {
-        delete error.value;
-        delete error.data;
-        return error;
-      });
-  
-      if (!errors.length) {
-        errors.push(this);
-      }
-  
-      if (Error.captureStackTrace) {
-        Error.captureStackTrace(this, this.constructor);
-      } else {
-        this.stack = (new Error()).stack;
-      }
-    }
+  static format(attrs) {
+    const { type, path } = attrs
+    const message = `Expected a value of type \`${type}\`${
+      path.length ? ` for \`${path.join('.')}\`` : ''
+    }.`
+    return message
   }
 
+  constructor(attrs) {
+    const message = StructErrorWithoutValue.format(attrs)
+    super(message)
+
+    const { path, reason, type, errors = [] } = attrs
+    this.path = path
+    this.reason = reason
+    this.type = type
+    this.errors = errors.map(error => {
+      delete error.value
+      delete error.data
+      return error
+    })
+
+    if (!errors.length) {
+      errors.push(this)
+    }
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    } else {
+      this.stack = new Error().stack
+    }
+  }
+}
+
 const struct = superstruct({
-    error: StructErrorWithoutValue,
+  error: StructErrorWithoutValue,
 })
 
 export const Struct = struct('number')

--- a/test/fixtures/custom-error/custom-error.js
+++ b/test/fixtures/custom-error/custom-error.js
@@ -1,0 +1,48 @@
+import { superstruct } from '../../..'
+
+class StructErrorWithoutValue extends TypeError {
+    static format(attrs) {
+      const { type, path } = attrs;
+      const message = `Expected a value of type \`${type}\`${path.length ? ` for \`${path.join('.')}\`` : ''}.`;
+      return message;
+    }
+  
+    constructor(attrs) {
+      const message = StructErrorWithoutValue.format(attrs);
+      super(message);
+  
+      const { path, reason, type, errors = [] } = attrs;
+      this.path = path;
+      this.reason = reason;
+      this.type = type;
+      this.errors = errors.map(error => {
+        delete error.value;
+        delete error.data;
+        return error;
+      });
+  
+      if (!errors.length) {
+        errors.push(this);
+      }
+  
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, this.constructor);
+      } else {
+        this.stack = (new Error()).stack;
+      }
+    }
+  }
+
+const struct = superstruct({
+    error: StructErrorWithoutValue,
+})
+
+export const Struct = struct('number')
+
+export const data = 'invalid'
+
+export const error = {
+  path: [],
+  type: 'number',
+  reason: null,
+}


### PR DESCRIPTION
Hi!

This introduces an `error` option on the `superstruct` export to define a custom error object superstruct will throw on invalidates.

```js
import { superstruct } from 'superstruct'

import CustomError from './somewhere/CustomError'

const struct = superstruct({
  error: CustomError,
})
```

I need to be able to get rid of the value in the error and I have two important reason for this.

1. I do not want to expose sensitive user data to my logs on my production system.
2. I implemented a length check to a string type with superstruct to prevent database denial of service. But still the DOS is possible by pollute the logs with huge strings exposed in the error messages.

Hope you get the idea and you like it. :)
Have a nice day.