### PR TITLE
Specify the specific type check that failed in an intersection shorthand

### DIFF
--- a/src/structs/intersection.ts
+++ b/src/structs/intersection.ts
@@ -32,7 +32,7 @@ export const createIntersection = (
       const [fs, v] = struct.check(value, branch, path)
 
       if (fs) {
-        return [[Struct.fail({ value, branch, path })]]
+        return [[Struct.fail({ value, branch, path, type: struct.type })]]
       } else {
         result = v
       }

--- a/test/fixtures/intersection-scalars/invalid.ts
+++ b/test/fixtures/intersection-scalars/invalid.ts
@@ -11,7 +11,7 @@ export const Struct = struct.intersection(['string', 'empty'])
 export const data = 'invalid'
 
 export const error = {
-  type: 'string & empty',
+  type: 'empty',
   value: 'invalid',
   path: [],
 }

--- a/test/fixtures/shorthand/intersection.ts
+++ b/test/fixtures/shorthand/intersection.ts
@@ -11,7 +11,7 @@ export const Struct = struct('string & empty')
 export const data = 'a'
 
 export const error = {
-  type: 'string & empty',
+  type: 'empty',
   value: 'a',
   path: [],
 }


### PR DESCRIPTION
Specify the specific type check that failed in an intersection shorthand. This way the errors are more useful (to return straight back to the user or parse for content).