### PR TITLE
Iterate objects with in, not of

### DIFF
--- a/src/structs/partial.ts
+++ b/src/structs/partial.ts
@@ -44,7 +44,7 @@ export const createPartial = (
     const result = {}
     const failures: Failure[] = []
 
-    for (const k of value) {
+    for (const k in value) {
       let v = value[k]
       const p = path.concat(k)
       const b = branch.concat(v)


### PR DESCRIPTION
struct.partial is evaluating whether a set of properties are correct for an object. [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in) states to iterate over keys in an object, you need for...in loops, not for...of.