### PR TITLE
Optional properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "test": "yarn build:types && yarn test:types && yarn build:cjs && yarn test:mocha",
     "test:mocha": "mocha --require ./test/register.cjs --require source-map-support/register ./test/index.ts",
     "test:types": "tsc --noEmit && tsc --project ./test/tsconfig.json --noEmit",
-    "watch": "yarn build:cjs --watch"
+    "watch": "yarn build:cjs --watch",
+    "watch:types": "yarn build:types --watch"
   },
   "keywords": [
     "api",

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,37 @@ export function number(): Struct<number> {
 }
 
 /**
+ * Type helper to Flatten the Union of optional and required properties.
+ */
+
+type Flatten<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
+
+/**
+ * Type helper to extract the optional keys of an object
+ */
+
+type OptionalKeys<T> = {
+  [K in keyof T]: undefined extends T[K] ? K : never
+}[keyof T]
+
+/**
+ * Type helper to extract the required keys of an object
+ */
+
+type RequiredKeys<T> = {
+  [K in keyof T]: undefined extends T[K] ? never : K
+}[keyof T]
+
+/**
+ * Type helper to create optional properties when the property value can be
+ * undefined (ie. when `optional()` is used to define a type)
+ */
+
+type OptionalizeObject<T> = Flatten<
+  { [K in RequiredKeys<T>]: T[K] } & { [K in OptionalKeys<T>]?: T[K] }
+>
+
+/**
  * Validate that an object with specific entry values.
  */
 
@@ -258,7 +289,7 @@ export function object<V extends StructRecord<any>>(): Struct<
 >
 export function object<V extends StructRecord<any>>(
   Structs: V
-): Struct<{ [K in keyof V]: StructType<V[K]> }, V>
+): Struct<OptionalizeObject<{ [K in keyof V]: StructType<V[K]> }>, V>
 export function object<V extends StructRecord<any>>(
   Structs?: V
 ): Struct<any, any> {

--- a/test/types/object.ts
+++ b/test/types/object.ts
@@ -1,4 +1,4 @@
-import { assert, object, number } from '../..'
+import { assert, object, optional, number, string } from '../..'
 import { test } from '..'
 
 test<Record<string, unknown>>((x) => {
@@ -8,5 +8,10 @@ test<Record<string, unknown>>((x) => {
 
 test<{ a: number }>((x) => {
   assert(x, object({ a: number() }))
+  return x
+})
+
+test<{ a?: number }>((x) => {
+  assert(x, object({ a: optional(number()) }))
   return x
 })

--- a/test/types/optional.ts
+++ b/test/types/optional.ts
@@ -6,7 +6,7 @@ test<string | undefined>((x) => {
   return x
 })
 
-test<{ a: string | undefined }>((x) => {
+test<{ a?: string | undefined }>((x) => {
   assert(x, object({ a: optional(string()) }))
   return x
 })


### PR DESCRIPTION
The purpose of the PR is to make `object()` types with `optional()` values appear as optional properties on an object. e.g.

```ts
// given
const struct = object({ a: optional(string()) })

// it should return this type (the `?` being the key change)
type X = {
  a?: string | undefined
}
```

There is also a related change to `package.json` which adds a script `watch:types`.  The purpose of this script is so that when there are changes to code, the TypeScript type definitions get updated. During the normal `watch`, type changes are not reflected. A better solution may be to add `build:types` as part of the `watch` script instead of in a separate `watch:types` script.

Stylistically, the type helpers are near the `object` code. There aren't any existing type helpers (at least in the code I saw) so the choice to locate the type helpers near the code is arbitrary. It may be preferable to place them in `utils`; however, the code isn't used anywhere else (ie. it's not shared) so I opted to put it right above the `object` code. Let me know if you prefer it elsewhere.