### PR TITLE
Added import using wildcard to docs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -33,11 +33,11 @@ import { assert } from 'superstruct'
 Superstruct has many importable methods. To reduce the friction of importing many methods you can use a wildcard. The methods are then accessed from one object.
 
 ```ts
-import * as be from 'superstruct'
+import * as s from 'superstruct'
 
-const User = be.object({
-  id: be.number(),
-  name: be.string(),
+const User = s.object({
+  id: s.number(),
+  name: s.string(),
 })
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -30,6 +30,17 @@ And then you can import it into your code base:
 import { assert } from 'superstruct'
 ```
 
+Superstruct has many importable methods. To reduce the friction of importing many methods you can use a wildcard. The methods are then accessed from one object.
+
+```ts
+import * as be from 'superstruct'
+
+const User = be.object({
+  id: be.number(),
+  name: be.string(),
+})
+```
+
 If you would rather import Superstruct with a `<script>` tag, you can use the bundled build:
 
 ```html
@@ -190,7 +201,7 @@ To define custom data types, we can use the [`struct`](https://superstructjs.org
 import { struct } from 'superstruct'
 import isEmail from 'is-email'
 
-const Email = struct('Email', value => isEmail(value))
+const Email = struct('Email', (value) => isEmail(value))
 ```
 
 Now we can define structs know about the `'email'` type:
@@ -355,7 +366,7 @@ For example, maybe you want to ensure that any string is trimmed before passing 
 ```ts
 import { coercion } from 'superstruct'
 
-const TrimmedString = coercion(string, value => {
+const TrimmedString = coercion(string, (value) => {
   return typeof value === 'string' ? value.trim() : value
 })
 ```

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "test": "yarn build:types && yarn test:types && yarn build:cjs && yarn test:mocha",
     "test:mocha": "mocha --require ./test/register.cjs --require source-map-support/register ./test/index.ts",
     "test:types": "tsc --noEmit && tsc --project ./test/tsconfig.json --noEmit",
-    "watch": "yarn build:cjs --watch"
+    "watch": "yarn build:cjs --watch",
+    "watch:types": "yarn build:types --watch"
   },
   "keywords": [
     "api",


### PR DESCRIPTION
As per https://github.com/ianstormtaylor/superstruct/issues/377

With respect to the documentation, I import the wildcard as `be` which is what my library was called but the reason is that it is fairly descriptive. e.g. `be.optional(be.string())`. It also doesn't conflict with other methods like `is`.

However, that's a personal choice. I can change it to something else like `ss` so we'd end up with `ss.optional(ss.string())`.