### PR TITLE
Update reference docs on `array`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -104,11 +104,12 @@ null
 
 ```ts
 array(number())
-array(object({ id: string() }))
+array(object({ name: number() }))
 ```
 
 ```ts
-;[1, 2, 3][{ id: '1' }]
+[1, 2, 3]
+[{ id: 1 }]
 ```
 
 `array` structs accept a list of values of a specific type.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -104,7 +104,7 @@ null
 
 ```ts
 array(number())
-array(object({ name: number() }))
+array(object({ id: number() }))
 ```
 
 ```ts


### PR DESCRIPTION
- Removes erroneous semicolon
- Moves two examples to separate lines
- Uses `id: number() -> { id: 1 }` instead of `id: string() -> id: '1'` because I felt that comprehension required _slightly_ more mental gymnastics when the id string happened to also be numerical.