### PR TITLE
chore(docs): Update `record` entry

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -296,7 +296,7 @@ partial({
 ### `record`
 
 ```ts
-record([string(), number()])
+record(string(), number())
 ```
 
 ```ts


### PR DESCRIPTION
Thanks for the great library!

While reading the new documentation to update a version I re-read the section on `record` and applied the syntax as given in the document. However, TypeScript complained and when looking at the test it's clear that the docs are incorrect on this one:

https://github.com/ianstormtaylor/superstruct/blob/master/test/types/record.ts