### PR TITLE
Fix ability to get multiple failures (#394)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -547,17 +547,17 @@ The error class that Superstruct uses for its validation errors. This is exposed
 
 Each error thrown includes the following properties:
 
-| **Property** | **Type**                 | **Example**             | **Description**                                                                                                                                                                                                        |
-| ------------ | ------------------------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `branch`     | `Array<any>`             | `[{...}, false]`        | An array of the values being validated at every layer. The first element in the array is the root value, and the last element is the current value that failed. This allows you to inspect the entire validation tree. |
-| `path`       | `Array<string | number>` | `['address', 'street']` | The path to the invalid value relative to the root value.                                                                                                                                                              |
-| `value`      | `any`                    | `false`                 | The invalid value.                                                                                                                                                                                                     |
-| `type`       | `string`                 | `'string'`              | The expected type of the invalid value.                                                                                                                                                                                |
-| `failures`   | `Array<StructFailure>`   | `[{...}]`               | All the validation failures that were encountered. The error object always represents the first failure, but you can write more complex logic involving other failures if you need to.                                 |
+| **Property** | **Type**                     | **Example**             | **Description**                                                                                                                                                                                                        |
+| ------------ | ---------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `branch`     | `Array<any>`                 | `[{...}, false]`        | An array of the values being validated at every layer. The first element in the array is the root value, and the last element is the current value that failed. This allows you to inspect the entire validation tree. |
+| `path`       | `Array<string | number>`     | `['address', 'street']` | The path to the invalid value relative to the root value.                                                                                                                                                              |
+| `value`      | `any`                        | `false`                 | The invalid value.                                                                                                                                                                                                     |
+| `type`       | `string`                     | `'string'`              | The expected type of the invalid value.                                                                                                                                                                                |
+| `failures`   | `() => Array<StructFailure>` |                         | A function that returns all the validation failures that were encountered. The error object always represents the first failure, but you can write more complex logic involving other failures if you need to.         |
 
 ### Multiple Errors
 
-The error thrown by Superstruct is always the first validation failure that was encountered, because this makes for convenient and simple logic in the majority of cases. However, the `failures` property is available with a list of all of the validation failures that occurred in case you want to add support for multiple error handling.
+The error thrown by Superstruct is always the first validation failure that was encountered, because this makes for convenient and simple logic in the majority of cases. However, the `failures` method will return a list of all of the validation failures that occurred in case you want to add support for multiple error handling.
 
 ## Utilities
 

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -47,7 +47,7 @@ export class StructError extends TypeError {
   type: string
   path: Array<number | string>
   branch: Array<any>
-  failures: () => Iterable<StructFailure>;
+  failures: () => Array<StructFailure>;
   [key: string]: any
 
   constructor(
@@ -60,7 +60,7 @@ export class StructError extends TypeError {
     } but received \`${JSON.stringify(value)}\`.`
 
     let failuresResult: Array<StructFailure> | undefined
-    function failures(): Iterable<StructFailure> {
+    function failures(): Array<StructFailure> {
       if (!failuresResult) {
         failuresResult = [failure, ...moreFailures]
       }
@@ -95,7 +95,7 @@ export type StructContext = {
     struct: Struct<any> | Struct<never>,
     parent?: any,
     key?: string | number
-  ) => Iterable<StructFailure>
+  ) => IterableIterator<StructFailure>
 }
 
 /**

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -1,4 +1,4 @@
-import { toFailures } from './utils'
+import { toFailures, iteratorShift } from './utils'
 
 /**
  * `Struct` objects encapsulate the schema for a specific data type (with
@@ -50,15 +50,21 @@ export class StructError extends TypeError {
   failures: () => Iterable<StructFailure>;
   [key: string]: any
 
-  constructor(failure: StructFailure, iterable: Iterable<StructFailure>) {
+  constructor(
+    failure: StructFailure,
+    moreFailures: IterableIterator<StructFailure>
+  ) {
     const { path, value, type, branch, ...rest } = failure
     const message = `Expected a value of type \`${type}\`${
       path.length ? ` for \`${path.join('.')}\`` : ''
     } but received \`${JSON.stringify(value)}\`.`
 
-    function* failures(): Iterable<StructFailure> {
-      yield failure
-      yield* iterable
+    let failuresResult: Array<StructFailure> | undefined
+    function failures(): Iterable<StructFailure> {
+      if (!failuresResult) {
+        failuresResult = [failure, ...moreFailures]
+      }
+      return failuresResult
     }
 
     super(message)
@@ -163,11 +169,11 @@ export function validate<T>(
     value = struct.coercer(value)
   }
 
-  const iterable = check(value, struct)
-  const [failure] = iterable
+  const failures = check(value, struct)
+  const failure = iteratorShift(failures)
 
   if (failure) {
-    const error = new StructError(failure, iterable)
+    const error = new StructError(failure, failures)
     return [error, undefined]
   } else {
     return [undefined, value as T]
@@ -183,7 +189,7 @@ function* check<T>(
   struct: Struct<T>,
   path: any[] = [],
   branch: any[] = []
-): Iterable<StructFailure> {
+): IterableIterator<StructFailure> {
   const { type } = struct
   const ctx: StructContext = {
     value,
@@ -201,7 +207,7 @@ function* check<T>(
   }
 
   const failures = toFailures(struct.validator(value, ctx), ctx)
-  const [failure] = failures
+  const failure = iteratorShift(failures)
 
   if (failure) {
     yield failure

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,15 +7,25 @@ export type StructTuple<T> = { [K in keyof T]: Struct<T[K]> }
  * Convert a validation result to an iterable of failures.
  */
 
-export function toFailures(
+export function* toFailures(
   result: StructResult,
   context: StructContext
-): Iterable<StructFailure> {
+): IterableIterator<StructFailure> {
   if (result === true) {
-    return []
+    // yield nothing
   } else if (result === false) {
-    return [context.fail()]
+    yield context.fail()
   } else {
-    return result
+    yield* result
   }
+}
+
+/**
+ * Shifts (removes and returns) the first value from the `input` iterator.
+ * Like `Array.prototype.shift()` but for an `Iterator`.
+ */
+
+export function iteratorShift<T>(input: Iterator<T>): T | undefined {
+  const { done, value } = input.next()
+  return done ? undefined : value
 }

--- a/test/fixtures/array/invalid-element-property.ts
+++ b/test/fixtures/array/invalid-element-property.ts
@@ -4,9 +4,11 @@ export const Struct = array(object({ id: string() }))
 
 export const data = [{ id: '1' }, { id: false }, { id: '3' }]
 
-export const error = {
-  value: false,
-  type: 'string',
-  path: [1, 'id'],
-  branch: [data, data[1], data[1].id],
-}
+export const failures = [
+  {
+    value: false,
+    type: 'string',
+    path: [1, 'id'],
+    branch: [data, data[1], data[1].id],
+  },
+]

--- a/test/fixtures/array/invalid-element.ts
+++ b/test/fixtures/array/invalid-element.ts
@@ -4,9 +4,11 @@ export const Struct = array(number())
 
 export const data = [1, 'invalid', 3]
 
-export const error = {
-  value: 'invalid',
-  type: 'number',
-  path: [1],
-  branch: [data, data[1]],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'number',
+    path: [1],
+    branch: [data, data[1]],
+  },
+]

--- a/test/fixtures/array/invalid-opaque.ts
+++ b/test/fixtures/array/invalid-opaque.ts
@@ -4,9 +4,11 @@ export const Struct = array()
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Array<unknown>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Array<unknown>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/array/invalid.ts
+++ b/test/fixtures/array/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = array(number())
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Array<number>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Array<number>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/boolean/invalid.ts
+++ b/test/fixtures/boolean/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = boolean()
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'boolean',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'boolean',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/date/invalid-date.ts
+++ b/test/fixtures/date/invalid-date.ts
@@ -4,9 +4,11 @@ export const Struct = date()
 
 export const data = new Date('invalid')
 
-export const error = {
-  value: data,
-  type: 'Date',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: data,
+    type: 'Date',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/date/invalid.ts
+++ b/test/fixtures/date/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = date()
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Date',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Date',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/dynamic/invalid-reference.ts
+++ b/test/fixtures/dynamic/invalid-reference.ts
@@ -29,9 +29,11 @@ export const data = {
   price: 'Only $19.99!',
 }
 
-export const error = {
-  value: 'Only $19.99!',
-  type: 'number',
-  path: ['price'],
-  branch: [data, data.price],
-}
+export const failures = [
+  {
+    value: 'Only $19.99!',
+    type: 'number',
+    path: ['price'],
+    branch: [data, data.price],
+  },
+]

--- a/test/fixtures/dynamic/invalid.ts
+++ b/test/fixtures/dynamic/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = dynamic(() => string())
 
 export const data = 3
 
-export const error = {
-  value: 3,
-  type: 'string',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 3,
+    type: 'string',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/empty/invalid-array.ts
+++ b/test/fixtures/empty/invalid-array.ts
@@ -4,9 +4,11 @@ export const Struct = empty(array())
 
 export const data = ['invalid']
 
-export const error = {
-  value: ['invalid'],
-  type: 'Array<unknown> & Empty',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: ['invalid'],
+    type: 'Array<unknown> & Empty',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/empty/invalid-string.ts
+++ b/test/fixtures/empty/invalid-string.ts
@@ -4,9 +4,11 @@ export const Struct = empty(string())
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'string & Empty',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'string & Empty',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/enums/invalid-numbers.ts
+++ b/test/fixtures/enums/invalid-numbers.ts
@@ -4,9 +4,11 @@ export const Struct = enums([1, 2])
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Enum<1,2>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Enum<1,2>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/enums/invalid-strings.ts
+++ b/test/fixtures/enums/invalid-strings.ts
@@ -4,9 +4,11 @@ export const Struct = enums(['one', 'two'])
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Enum<"one","two">',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Enum<"one","two">',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/function/invalid.ts
+++ b/test/fixtures/function/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = func()
 
 export const data = false
 
-export const error = {
-  value: false,
-  type: 'Function',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: false,
+    type: 'Function',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/instance/invalid.ts
+++ b/test/fixtures/instance/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = instance(Array)
 
 export const data = false
 
-export const error = {
-  value: false,
-  type: 'InstanceOf<Array>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: false,
+    type: 'InstanceOf<Array>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/intersection/invalid.ts
+++ b/test/fixtures/intersection/invalid.ts
@@ -10,9 +10,11 @@ export const data = {
   b: 'invalid',
 }
 
-export const error = {
-  type: 'number',
-  value: 'invalid',
-  path: ['b'],
-  branch: [data, data.b],
-}
+export const failures = [
+  {
+    type: 'number',
+    value: 'invalid',
+    path: ['b'],
+    branch: [data, data.b],
+  },
+]

--- a/test/fixtures/lazy/invalid.ts
+++ b/test/fixtures/lazy/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = lazy(() => string())
 
 export const data = 3
 
-export const error = {
-  value: 3,
-  type: 'string',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 3,
+    type: 'string',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/length/invalid-array.ts
+++ b/test/fixtures/length/invalid-array.ts
@@ -4,9 +4,11 @@ export const Struct = length(array(number()), 1, 5)
 
 export const data = []
 
-export const error = {
-  value: [],
-  type: 'Array<number> & Length<1,5>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: [],
+    type: 'Array<number> & Length<1,5>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/length/invalid-string.ts
+++ b/test/fixtures/length/invalid-string.ts
@@ -4,9 +4,11 @@ export const Struct = length(string(), 1, 5)
 
 export const data = ''
 
-export const error = {
-  value: '',
-  type: 'string & Length<1,5>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: '',
+    type: 'string & Length<1,5>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/literal/invalid.ts
+++ b/test/fixtures/literal/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = literal(42)
 
 export const data = false
 
-export const error = {
-  value: false,
-  type: 'Literal<42>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: false,
+    type: 'Literal<42>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/map/invalid-property.ts
+++ b/test/fixtures/map/invalid-property.ts
@@ -7,9 +7,17 @@ export const data = new Map([
   ['b', 'b'],
 ])
 
-export const error = {
-  value: 'a',
-  type: 'number',
-  path: ['a'],
-  branch: [data, 'a'],
-}
+export const failures = [
+  {
+    value: 'a',
+    type: 'number',
+    path: ['a'],
+    branch: [data, 'a'],
+  },
+  {
+    value: 'b',
+    type: 'number',
+    path: ['b'],
+    branch: [data, 'b'],
+  },
+]

--- a/test/fixtures/map/invalid.ts
+++ b/test/fixtures/map/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = map(string(), number())
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Map<string,number>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Map<string,number>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/masked/not-masked.ts
+++ b/test/fixtures/masked/not-masked.ts
@@ -4,11 +4,13 @@ export const Struct = masked(object({ name: string() }))
 
 export const data = false
 
-export const error = {
-  type: 'Object<{name}>',
-  value: false,
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    type: 'Object<{name}>',
+    value: false,
+    path: [],
+    branch: [data],
+  },
+]
 
 export const coerce = true

--- a/test/fixtures/never/invalid.ts
+++ b/test/fixtures/never/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = never()
 
 export const data = true
 
-export const error = {
-  value: true,
-  type: 'never',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: true,
+    type: 'never',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/nullable/invalid.ts
+++ b/test/fixtures/nullable/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = nullable(number())
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'number',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'number',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/number/invalid.ts
+++ b/test/fixtures/number/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = number()
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'number',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'number',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/object/invalid-element-nested.ts
+++ b/test/fixtures/object/invalid-element-nested.ts
@@ -10,9 +10,11 @@ export const data = {
   emails: ['name@example.com', false],
 }
 
-export const error = {
-  value: false,
-  type: 'string',
-  path: ['emails', 1],
-  branch: [data, data.emails, data.emails[1]],
-}
+export const failures = [
+  {
+    value: false,
+    type: 'string',
+    path: ['emails', 1],
+    branch: [data, data.emails, data.emails[1]],
+  },
+]

--- a/test/fixtures/object/invalid-opaque.ts
+++ b/test/fixtures/object/invalid-opaque.ts
@@ -4,9 +4,11 @@ export const Struct = object()
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Object',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Object',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/object/invalid-property-nested.ts
+++ b/test/fixtures/object/invalid-property-nested.ts
@@ -16,9 +16,11 @@ export const data = {
   },
 }
 
-export const error = {
-  value: 123,
-  type: 'string',
-  path: ['address', 'street'],
-  branch: [data, data.address, data.address.street],
-}
+export const failures = [
+  {
+    value: 123,
+    type: 'string',
+    path: ['address', 'street'],
+    branch: [data, data.address, data.address.street],
+  },
+]

--- a/test/fixtures/object/invalid-property-unknown.ts
+++ b/test/fixtures/object/invalid-property-unknown.ts
@@ -11,9 +11,11 @@ export const data = {
   unknown: true,
 }
 
-export const error = {
-  value: true,
-  type: 'never',
-  path: ['unknown'],
-  branch: [data, data.unknown],
-}
+export const failures = [
+  {
+    value: true,
+    type: 'never',
+    path: ['unknown'],
+    branch: [data, data.unknown],
+  },
+]

--- a/test/fixtures/object/invalid-property.ts
+++ b/test/fixtures/object/invalid-property.ts
@@ -3,16 +3,26 @@ import { object, string, number } from '../../..'
 export const Struct = object({
   name: string(),
   age: number(),
+  height: string(),
 })
 
 export const data = {
   name: 'john',
   age: 'invalid',
+  height: 2,
 }
 
-export const error = {
-  value: 'invalid',
-  type: 'number',
-  path: ['age'],
-  branch: [data, data.age],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'number',
+    path: ['age'],
+    branch: [data, data.age],
+  },
+  {
+    value: 2,
+    type: 'string',
+    path: ['height'],
+    branch: [data, data.height],
+  },
+]

--- a/test/fixtures/object/invalid-referential.ts
+++ b/test/fixtures/object/invalid-referential.ts
@@ -16,9 +16,11 @@ export const data = {
   subsection: '2.1',
 }
 
-export const error = {
-  value: '2.1',
-  type: 'Subsection',
-  path: ['subsection'],
-  branch: [data, data.subsection],
-}
+export const failures = [
+  {
+    value: '2.1',
+    type: 'Subsection',
+    path: ['subsection'],
+    branch: [data, data.subsection],
+  },
+]

--- a/test/fixtures/object/invalid.ts
+++ b/test/fixtures/object/invalid.ts
@@ -7,9 +7,11 @@ export const Struct = object({
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Object<{name,age}>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Object<{name,age}>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/optional/invalid.ts
+++ b/test/fixtures/optional/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = optional(number())
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'number',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'number',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/partial/invalid-property-unknown.ts
+++ b/test/fixtures/partial/invalid-property-unknown.ts
@@ -10,9 +10,11 @@ export const data = {
   unknown: true,
 }
 
-export const error = {
-  value: true,
-  type: 'never',
-  path: ['unknown'],
-  branch: [data, data.unknown],
-}
+export const failures = [
+  {
+    value: true,
+    type: 'never',
+    path: ['unknown'],
+    branch: [data, data.unknown],
+  },
+]

--- a/test/fixtures/partial/invalid-property.ts
+++ b/test/fixtures/partial/invalid-property.ts
@@ -9,9 +9,11 @@ export const data = {
   age: 'invalid',
 }
 
-export const error = {
-  value: 'invalid',
-  type: 'number',
-  path: ['age'],
-  branch: [data, data.age],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'number',
+    path: ['age'],
+    branch: [data, data.age],
+  },
+]

--- a/test/fixtures/partial/invalid.ts
+++ b/test/fixtures/partial/invalid.ts
@@ -7,9 +7,11 @@ export const Struct = partial({
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Partial<{name,age}>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Partial<{name,age}>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/pattern/invalid.ts
+++ b/test/fixtures/pattern/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = pattern(string(), /\d+/)
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'string & Pattern<\\d+>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'string & Pattern<\\d+>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/record/invalid-property.ts
+++ b/test/fixtures/record/invalid-property.ts
@@ -7,9 +7,17 @@ export const data = {
   b: 'b',
 }
 
-export const error = {
-  value: 'a',
-  type: 'number',
-  path: ['a'],
-  branch: [data, data.a],
-}
+export const failures = [
+  {
+    value: 'a',
+    type: 'number',
+    path: ['a'],
+    branch: [data, data.a],
+  },
+  {
+    value: 'b',
+    type: 'number',
+    path: ['b'],
+    branch: [data, data.b],
+  },
+]

--- a/test/fixtures/record/invalid.ts
+++ b/test/fixtures/record/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = record(string(), number())
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Record<string,number>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Record<string,number>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/refinement/invalid.ts
+++ b/test/fixtures/refinement/invalid.ts
@@ -5,9 +5,11 @@ export const Struct = refinement(string(), 'Email', isEmail)
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Email',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Email',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/set/invalid-element.ts
+++ b/test/fixtures/set/invalid-element.ts
@@ -4,9 +4,11 @@ export const Struct = set(number())
 
 export const data = new Set([1, 'b', 3])
 
-export const error = {
-  value: new Set([1, 'b', 3]),
-  type: 'Set<number>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: new Set([1, 'b', 3]),
+    type: 'Set<number>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/set/invalid.ts
+++ b/test/fixtures/set/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = set(number())
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Set<number>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Set<number>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/string/invalid.ts
+++ b/test/fixtures/string/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = string()
 
 export const data = false
 
-export const error = {
-  value: false,
-  type: 'string',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: false,
+    type: 'string',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/tuple/invalid-element-missing.ts
+++ b/test/fixtures/tuple/invalid-element-missing.ts
@@ -4,9 +4,11 @@ export const Struct = tuple([string(), number()])
 
 export const data = ['A']
 
-export const error = {
-  value: undefined,
-  type: 'number',
-  path: [1],
-  branch: [data, data[1]],
-}
+export const failures = [
+  {
+    value: undefined,
+    type: 'number',
+    path: [1],
+    branch: [data, data[1]],
+  },
+]

--- a/test/fixtures/tuple/invalid-element-unknown.ts
+++ b/test/fixtures/tuple/invalid-element-unknown.ts
@@ -4,9 +4,11 @@ export const Struct = tuple([string(), number()])
 
 export const data = ['A', 3, 'unknown']
 
-export const error = {
-  value: 'unknown',
-  type: 'never',
-  path: [2],
-  branch: [data, data[2]],
-}
+export const failures = [
+  {
+    value: 'unknown',
+    type: 'never',
+    path: [2],
+    branch: [data, data[2]],
+  },
+]

--- a/test/fixtures/tuple/invalid-element.ts
+++ b/test/fixtures/tuple/invalid-element.ts
@@ -4,9 +4,11 @@ export const Struct = tuple([string(), number()])
 
 export const data = [false, 3]
 
-export const error = {
-  value: false,
-  type: 'string',
-  path: [0],
-  branch: [data, data[0]],
-}
+export const failures = [
+  {
+    value: false,
+    type: 'string',
+    path: [0],
+    branch: [data, data[0]],
+  },
+]

--- a/test/fixtures/tuple/invalid.ts
+++ b/test/fixtures/tuple/invalid.ts
@@ -4,9 +4,11 @@ export const Struct = tuple([string(), number()])
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: '[string,number]',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: '[string,number]',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/type/invalid-property-nested.ts
+++ b/test/fixtures/type/invalid-property-nested.ts
@@ -12,9 +12,11 @@ export const data = {
   id: 1,
 }
 
-export const error = {
-  value: undefined,
-  type: 'Type<{name,age}>',
-  path: ['person'],
-  branch: [data, undefined],
-}
+export const failures = [
+  {
+    value: undefined,
+    type: 'Type<{name,age}>',
+    path: ['person'],
+    branch: [data, undefined],
+  },
+]

--- a/test/fixtures/type/invalid-property.ts
+++ b/test/fixtures/type/invalid-property.ts
@@ -10,9 +10,11 @@ export const data = {
   age: 'invalid',
 }
 
-export const error = {
-  value: 'invalid',
-  type: 'number',
-  path: ['age'],
-  branch: [data, data.age],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'number',
+    path: ['age'],
+    branch: [data, data.age],
+  },
+]

--- a/test/fixtures/type/invalid.ts
+++ b/test/fixtures/type/invalid.ts
@@ -7,9 +7,11 @@ export const Struct = type({
 
 export const data = 'invalid'
 
-export const error = {
-  value: 'invalid',
-  type: 'Type<{name,age}>',
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'Type<{name,age}>',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/fixtures/union/invalid.ts
+++ b/test/fixtures/union/invalid.ts
@@ -9,9 +9,11 @@ export const data = {
   b: 'invalid',
 }
 
-export const error = {
-  type: 'Type<{a}> | Type<{b}>',
-  value: { b: 'invalid' },
-  path: [],
-  branch: [data],
-}
+export const failures = [
+  {
+    type: 'Type<{a}> | Type<{b}>',
+    value: { b: 'invalid' },
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/index.ts
+++ b/test/index.ts
@@ -21,9 +21,6 @@ describe('superstruct', () => {
 
       for (const name of tests) {
         const module = require(resolve(testsDir, name))
-        if ('error' in module) {
-          module.failures = [module.error]
-        }
         const { Struct, data, coerce, only, skip, output, failures } = module
         const run = only ? it.only : skip ? it.skip : it
         run(name, () => {
@@ -66,7 +63,7 @@ describe('superstruct', () => {
             )
           } else {
             throw new Error(
-              `The "${name}" fixture did not define an \`output\` or \`error\` or \`failures\` export.`
+              `The "${name}" fixture did not define an \`output\` or \`failures\` export.`
             )
           }
         })

--- a/test/index.ts
+++ b/test/index.ts
@@ -56,7 +56,7 @@ describe('superstruct', () => {
               )
             }
 
-            const actualFailures = Array.from(err.failures()).map((failure) =>
+            const actualFailures = (err.failures() as object[]).map((failure) =>
               pick(failure, 'type', 'path', 'value', 'branch')
             )
             assert.deepEqual(actualFailures, failures)


### PR DESCRIPTION
Fixes #394 


## Problem

So I figured it out. Here's the problematic code:
https://github.com/ianstormtaylor/superstruct/blob/b0ca695995b96e4eb4caf0dec09f712654f1d0e1/src/struct.ts#L166-L167
and
https://github.com/ianstormtaylor/superstruct/blob/b0ca695995b96e4eb4caf0dec09f712654f1d0e1/src/struct.ts#L203-L204

In the first snippet, `check` is a `GeneratorFunction` so the return value is always a `Generator` (despite being typed as a simple `Iterator`).

In the second snippet, `toFailures` *sometimes* returns a `Generator`. 

A `Generator` is indeed technically an `Iterable`, but it is more specifically a `IterableIterator` (special kind of `Iterator` which also implements `Iterable`). 

More importantly, a generator's `Symbol.iterator` method should be called **only once**. If it is called a second time, it will return an iterator that completes without yielding any values (even if the first iterator did not consume all the generator's values). See example below for proof.

<details>
<summary>example</summary>

```js
function * generatorFunction () {
  for (let i = 0; i < 10; i++) {
    yield i
  }
}

let generator = generatorFunction()

let [a, b] = generator
let [c, d] = generator

console.log({a, b, c, d})
// { a: 0, b: 1, c: undefined, d: undefined }
```

</details>

So in the second line of each of the above snippets, when we implicitly call `iterable[Symbol.iterator]()` and save only the first value from the resulting iterator, we are losing the rest of the values forever. 

## Solution

Do not attempt to iterate on `Generator`s more than once (b8b6b5758713a39681a69371217464cfa3f9d8b2)

## Additional changes

- Updates to tests
    - Test for multiple failures (with minimal changes to tests) (1ffa1fd7ef772a827989de8299d7bdb924690f8f)
    - Clean up tests: Have all fixtures export `failures` instead of `error` (a8024a4089acfd4d9ef8f635366110d734402bcf, last commit)
    We can revert this commit and clean [this hack](https://github.com/ianstormtaylor/superstruct/blob/1ffa1fd7ef772a827989de8299d7bdb924690f8f/test/index.ts#L23-L27) (committed in 1ffa1fd7ef772a827989de8299d7bdb924690f8f) another way if you prefer.
- Refined some types in the public API (non-breaking changes) (a85c0db51b56af6fb4bc79996c76666dc033a671)
    - Return type of `StructError.failures` is now `Array<StructFailure>` instead of less specific `Iterable<StructFailure>`. 
    This more closely resembles [the current documentation](https://github.com/ianstormtaylor/superstruct/blob/b0ca695995b96e4eb4caf0dec09f712654f1d0e1/docs/reference.md#error-properties) and is the type users probably want.
    - Return type of `StructContext.check` is now `IterableIterator<StructFailure>` instead of less specific `Iterable<StructFailure>`.
    This more accurately reflects the way it has always been.
- Update documentation regarding StructError.failures (d98fe64f3d4e3b170342c65587c8d97c3a15ce75)