### PR TITLE
Fix partial reference docs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -286,12 +286,10 @@ partial({
 ```ts
 {
   a: 1,
-  b: 2,
-  c: 3,
 }
 ```
 
-`partial` structs are similar to `object` structs, but they only require that the specified properties exist, and they don't care about other properties on the object.
+`partial` structs are similar to `object` structs, but all specified properties are optional.
 
 ### `record`
 


### PR DESCRIPTION
Right now implementation of `partial` contradicts its description in docs. Current behavior:
```ts
assert(
  { a:1 },
  partial({ a: number(), b: number() }),
) // ok
```

See https://github.com/ianstormtaylor/superstruct/issues/405#issuecomment-687128744

Fixes https://github.com/ianstormtaylor/superstruct/issues/405