### PR TITLE
Add conditional exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "types": "./lib/index.d.ts",
   "main": "./lib/index.cjs",
   "module": "./lib/index.es.js",
+  "exports": {
+    "import": "./lib/index.es.js",
+    "require": "./lib/index.cjs"
+  },
   "sideEffects": false,
   "files": [
     "umd",


### PR DESCRIPTION
This PR is in reference to my comment on #404 .  In brief, Node.js projects of type `module` are not able to import Superstruct without this change to `package.json`

I tested this locally and was successfully able to import and use Superstruct into a Node.js package of type `module`.