### PR TITLE
feat(reuired): add required with custom message

### DIFF
--- a/src/structs/refinements.ts
+++ b/src/structs/refinements.ts
@@ -27,6 +27,17 @@ export function empty<
   })
 }
 
+export function reqiured<T extends string | any[], S extends any>(
+  struct: Struct<T, S>,
+  message?: string
+): Struct<T, S> {
+  const expected = `Expected required ${struct.type} but received empty`
+
+  return refine<T, S>(struct, 'reqiured', (value) => {
+    return value.length > 0 || (message ?? expected)
+  })
+}
+
 /**
  * Ensure that a number or date is below a threshold.
  */


### PR DESCRIPTION
New refinements - required
Contains [custom errors](https://github.com/ianstormtaylor/superstruct/issues/568)

Technically this is the same as using size, but "required" feels slightly nicer and will give a slightly easier to read error.
i borrowed this comment from empty