### PR TITLE
Typed error

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -2,7 +2,7 @@
  * A `StructFailure` represents a single specific failure in validation.
  */
 
-export type Failure = {
+export type Failure<E extends Error> = {
   value: any
   key: any
   type: string
@@ -10,6 +10,37 @@ export type Failure = {
   message: string
   branch: Array<any>
   path: Array<any>
+  detail: E
+  failures?: Failure<E>[]
+}
+
+export type Error = ErrorDetail | never;
+export interface ErrorDetail {
+  class: string;
+  message?: string;
+}
+export interface BasicErrorDetail extends ErrorDetail {
+  class: 'basic';
+  except: string;
+  actually: string;
+}
+
+export interface TypeErrorDetail extends ErrorDetail {
+  class: 'type';
+  except: string;
+  actually: unknown;
+}
+
+export interface ValuesErrorDetail<T> extends ErrorDetail {
+  class: 'values';
+  except: T[];
+  actually: T;
+}
+
+export interface ValueErrorDetail<T> extends ErrorDetail {
+  class: 'value';
+  except: T;
+  actually: unknown;
 }
 
 /**
@@ -21,24 +52,26 @@ export type Failure = {
  * continue validation and receive all the failures in the data.
  */
 
-export class StructError extends TypeError {
+export class StructError<E extends Error> extends TypeError {
   value: any
   key!: any
   type!: string
   refinement!: string | undefined
   path!: Array<any>
   branch!: Array<any>
-  failures: () => Array<Failure>;
+  failures: () => Array<Failure<E>>;
+  detail: E;
   [x: string]: any
 
-  constructor(failure: Failure, failures: () => Generator<Failure>) {
-    let cached: Array<Failure> | undefined
+  constructor(failure: Failure<E>, failures: () => Generator<Failure<E>>) {
+    let cached: Array<Failure<E>> | undefined
     const { message, ...rest } = failure
-    const { path } = failure
+    const { path, detail } = failure
     const msg =
       path.length === 0 ? message : `At path: ${path.join('.')} -- ${message}`
-    super(msg)
-    Object.assign(this, rest)
+      super(msg)
+      Object.assign(this, rest)
+    this.detail = detail;
     this.name = this.constructor.name
     this.failures = () => {
       return (cached ??= [failure, ...failures()])

--- a/src/error.ts
+++ b/src/error.ts
@@ -19,10 +19,9 @@ export interface ErrorDetail {
   class: string
   message?: string
 }
-export interface BasicErrorDetail extends ErrorDetail {
-  class: 'basic'
-  except: string
-  actually: string
+export interface GenericErrorDetail extends ErrorDetail {
+  class: 'generic'
+  message: string
 }
 
 export interface TypeErrorDetail extends ErrorDetail {

--- a/src/error.ts
+++ b/src/error.ts
@@ -14,33 +14,38 @@ export type Failure<E extends Error> = {
   failures?: Failure<E>[]
 }
 
-export type Error = ErrorDetail | never;
+export type Error = ErrorDetail | never
 export interface ErrorDetail {
-  class: string;
-  message?: string;
+  class: string
+  message?: string
 }
 export interface BasicErrorDetail extends ErrorDetail {
-  class: 'basic';
-  except: string;
-  actually: string;
+  class: 'basic'
+  except: string
+  actually: string
 }
 
 export interface TypeErrorDetail extends ErrorDetail {
-  class: 'type';
-  except: string;
-  actually: unknown;
+  class: 'type'
+  except: string
+  actually: unknown
 }
 
 export interface ValuesErrorDetail<T> extends ErrorDetail {
-  class: 'values';
-  except: T[];
-  actually: T;
+  class: 'values'
+  except: T[]
+  actually: T
 }
 
 export interface ValueErrorDetail<T> extends ErrorDetail {
-  class: 'value';
-  except: T;
-  actually: unknown;
+  class: 'value'
+  except: T
+  actually: unknown
+}
+
+export interface ThrowErrorDetail extends ErrorDetail {
+  class: 'throw'
+  error: any
 }
 
 /**
@@ -59,7 +64,7 @@ export class StructError<E extends Error> extends TypeError {
   refinement!: string | undefined
   path!: Array<any>
   branch!: Array<any>
-  failures: () => Array<Failure<E>>;
+  failures: () => Array<Failure<E>>
   detail: E;
   [x: string]: any
 
@@ -69,9 +74,9 @@ export class StructError<E extends Error> extends TypeError {
     const { path, detail } = failure
     const msg =
       path.length === 0 ? message : `At path: ${path.join('.')} -- ${message}`
-      super(msg)
-      Object.assign(this, rest)
-    this.detail = detail;
+    super(msg)
+    Object.assign(this, rest)
+    this.detail = detail
     this.name = this.constructor.name
     this.failures = () => {
       return (cached ??= [failure, ...failures()])

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -236,6 +236,8 @@ export type Infer<T extends Struct<any, any, any>> = T['TYPE']
 
 export type Describe<T> = Struct<T, StructSchema<T>, any> // todo
 
+export type InferError<T> = T extends Struct<any, any, infer E> ? E : Error
+
 /**
  * A `Result` is returned from validation functions.
  */

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -234,7 +234,7 @@ export type Infer<T extends Struct<any, any, any>> = T['TYPE']
  * A type utility to describe that a struct represents a TypeScript type.
  */
 
-export type Describe<T> = Struct<T, StructSchema<T>>
+export type Describe<T> = Struct<T, StructSchema<T>, any> // todo
 
 /**
  * A `Result` is returned from validation functions.
@@ -265,7 +265,12 @@ export type Coercer<T = unknown> = (value: T, context: Context) => unknown
 export type Validator<E extends ErrorDetail> = (
   value: unknown,
   context: Context
-) => Iterable<E | Failure<E>> | undefined | true
+) => Iterable<E | Failure<E>> | true
+
+export type SimpleValidator = (
+  value: unknown,
+  context: Context
+) => string | boolean | undefined
 
 /**
  * A `Refiner` takes a value of a known type and validates it against a further
@@ -275,4 +280,9 @@ export type Validator<E extends ErrorDetail> = (
 export type Refiner<T, E extends ErrorDetail> = (
   value: T,
   context: Context
-) => Iterable<E | Failure<E>> | undefined | true
+) => Iterable<E | Failure<E>> | true
+
+export type SimpleRefiner<T> = (
+  value: T,
+  context: Context
+) => string | boolean | undefined

--- a/src/structs/coercions.ts
+++ b/src/structs/coercions.ts
@@ -36,13 +36,13 @@ export function coerce<T, S, C, E1 extends Error, E2 extends Error>(
  * take effect! Using simply `assert()` or `is()` will not use coercion.
  */
 
-export function defaulted<T, S>(
-  struct: Struct<T, S>,
+export function defaulted<T, S, E extends Error>(
+  struct: Struct<T, S, E>,
   fallback: any,
   options: {
     strict?: boolean
   } = {}
-): Struct<T, S> {
+): Struct<T, S, E> {
   return coerce(struct, unknown(), (x) => {
     const f = typeof fallback === 'function' ? fallback() : fallback
 

--- a/src/structs/coercions.ts
+++ b/src/structs/coercions.ts
@@ -19,7 +19,7 @@ export function coerce<T, S, C, E1 extends Error, E2 extends Error>(
   condition: Struct<C, any, E2>,
   coercer: Coercer<C>
 ): Struct<T, S, E1 | E2> {
-  return new Struct<T,S,E1 | E2>({
+  return new Struct<T, S, E1 | E2>({
     ...struct,
     coercer: (value, ctx) => {
       return is(value, condition)
@@ -77,7 +77,9 @@ export function defaulted<T, S>(
  * take effect! Using simply `assert()` or `is()` will not use coercion.
  */
 
-export function masked<T, S, E extends Error>(struct: Struct<T, S, E>): Struct<T, S, E> {
+export function masked<T, S, E extends Error>(
+  struct: Struct<T, S, E>
+): Struct<T, S, E> {
   return coerce(struct, unknown(), (x) => {
     if (
       typeof struct.schema !== 'object' ||
@@ -107,6 +109,8 @@ export function masked<T, S, E extends Error>(struct: Struct<T, S, E>): Struct<T
  * take effect! Using simply `assert()` or `is()` will not use coercion.
  */
 
-export function trimmed<T, S, E extends Error>(struct: Struct<T, S, E>): Struct<T, S, E|TypeErrorDetail> {
+export function trimmed<T, S, E extends Error>(
+  struct: Struct<T, S, E>
+): Struct<T, S, E | TypeErrorDetail> {
   return coerce(struct, string(), (x) => x.trim())
 }

--- a/src/structs/coercions.ts
+++ b/src/structs/coercions.ts
@@ -1,3 +1,4 @@
+import { Error, TypeErrorDetail } from '../error'
 import { Struct, is, Coercer } from '../struct'
 import { isPlainObject } from '../utils'
 import { string, unknown } from './types'
@@ -13,12 +14,12 @@ import { string, unknown } from './types'
  * take effect! Using simply `assert()` or `is()` will not use coercion.
  */
 
-export function coerce<T, S, C>(
-  struct: Struct<T, S>,
-  condition: Struct<C, any>,
+export function coerce<T, S, C, E1 extends Error, E2 extends Error>(
+  struct: Struct<T, S, E1>,
+  condition: Struct<C, any, E2>,
   coercer: Coercer<C>
-): Struct<T, S> {
-  return new Struct({
+): Struct<T, S, E1 | E2> {
+  return new Struct<T,S,E1 | E2>({
     ...struct,
     coercer: (value, ctx) => {
       return is(value, condition)
@@ -76,7 +77,7 @@ export function defaulted<T, S>(
  * take effect! Using simply `assert()` or `is()` will not use coercion.
  */
 
-export function masked<T, S>(struct: Struct<T, S>): Struct<T, S> {
+export function masked<T, S, E extends Error>(struct: Struct<T, S, E>): Struct<T, S, E> {
   return coerce(struct, unknown(), (x) => {
     if (
       typeof struct.schema !== 'object' ||
@@ -106,6 +107,6 @@ export function masked<T, S>(struct: Struct<T, S>): Struct<T, S> {
  * take effect! Using simply `assert()` or `is()` will not use coercion.
  */
 
-export function trimmed<T, S>(struct: Struct<T, S>): Struct<T, S> {
+export function trimmed<T, S, E extends Error>(struct: Struct<T, S, E>): Struct<T, S, E|TypeErrorDetail> {
   return coerce(struct, string(), (x) => x.trim())
 }

--- a/src/structs/refinements.ts
+++ b/src/structs/refinements.ts
@@ -1,5 +1,16 @@
+/* eslint-disable no-shadow */
+import { ErrorDetail, ValueErrorDetail } from '../error'
 import { Struct, Refiner } from '../struct'
 import { toFailures } from '../utils'
+
+interface SizeErrorDetail<T extends number | Date> extends ErrorDetail {
+  class: 'size'
+  actually: T
+  min: T | undefined
+  max: T | undefined
+  minExlusive: boolean
+  maxExlusive: boolean
+}
 
 /**
  * Ensure that a string, array, map, or set is empty.
@@ -7,21 +18,43 @@ import { toFailures } from '../utils'
 
 export function empty<
   T extends string | any[] | Map<any, any> | Set<any>,
-  S extends any
->(struct: Struct<T, S>): Struct<T, S> {
+  S extends any,
+  E extends ErrorDetail
+>(struct: Struct<T, S, E>): Struct<T, S, E | SizeErrorDetail<number>> {
   const expected = `Expected an empty ${struct.type}`
 
-  return refine(struct, 'empty', (value) => {
+  return refine<T, S, E, SizeErrorDetail<number>>(struct, 'empty', (value) => {
     if (value instanceof Map || value instanceof Set) {
       const { size } = value
       return (
-        size === 0 || `${expected} but received one with a size of \`${size}\``
+        size === 0 ||
+        ([
+          {
+            class: 'size',
+            actually: size,
+            min: 0,
+            max: 0,
+            minExlusive: false,
+            maxExlusive: false,
+            message: `${expected} but received one with a size of \`${size}\``,
+          },
+        ] as SizeErrorDetail<number>[])
       )
     } else {
       const { length } = value as string | any[]
       return (
         length === 0 ||
-        `${expected} but received one with a length of \`${length}\``
+        ([
+          {
+            class: 'size',
+            actually: length,
+            min: 0,
+            max: 0,
+            minExlusive: false,
+            maxExlusive: false,
+            message: `${expected} but received one with a length of \`${length}\``,
+          },
+        ] as SizeErrorDetail<number>[])
       )
     }
   })
@@ -31,21 +64,35 @@ export function empty<
  * Ensure that a number or date is below a threshold.
  */
 
-export function max<T extends number | Date, S extends any>(
-  struct: Struct<T, S>,
+export function max<
+  T extends number | Date,
+  S extends any,
+  E extends ErrorDetail
+>(
+  struct: Struct<T, S, E>,
   threshold: T,
   options: {
     exclusive?: boolean
   } = {}
-): Struct<T, S> {
+): Struct<T, S, E | SizeErrorDetail<T>> {
   const { exclusive } = options
   return refine(struct, 'max', (value) => {
-    return exclusive
-      ? value < threshold
-      : value <= threshold ||
-          `Expected a ${struct.type} greater than ${
+    return (
+      (exclusive ? value < threshold : value <= threshold) ||
+      ([
+        {
+          class: 'size',
+          actually: value,
+          min: undefined,
+          max: threshold,
+          minExlusive: false,
+          maxExlusive: exclusive,
+          message: `Expected a ${struct.type} greater than ${
             exclusive ? '' : 'or equal to '
-          }${threshold} but received \`${value}\``
+          }${threshold} but received \`${value}\``,
+        },
+      ] as SizeErrorDetail<T>[])
+    )
   })
 }
 
@@ -53,35 +100,56 @@ export function max<T extends number | Date, S extends any>(
  * Ensure that a number or date is above a threshold.
  */
 
-export function min<T extends number | Date, S extends any>(
-  struct: Struct<T, S>,
+export function min<
+  T extends number | Date,
+  S extends any,
+  E extends ErrorDetail
+>(
+  struct: Struct<T, S, E>,
   threshold: T,
   options: {
     exclusive?: boolean
   } = {}
-): Struct<T, S> {
+): Struct<T, S, E | SizeErrorDetail<T>> {
   const { exclusive } = options
   return refine(struct, 'min', (value) => {
-    return exclusive
-      ? value > threshold
-      : value >= threshold ||
-          `Expected a ${struct.type} greater than ${
+    return (
+      (exclusive ? value > threshold : value >= threshold) ||
+      ([
+        {
+          class: 'size',
+          actually: value,
+          min: threshold,
+          max: undefined,
+          minExlusive: exclusive,
+          maxExlusive: false,
+          message: `Expected a ${struct.type} greater than ${
             exclusive ? '' : 'or equal to '
-          }${threshold} but received \`${value}\``
+          }${threshold} but received \`${value}\``,
+        },
+      ] as SizeErrorDetail<T>[])
+    )
   })
 }
 /**
  * Ensure that a string matches a regular expression.
  */
 
-export function pattern<T extends string, S extends any>(
-  struct: Struct<T, S>,
+export function pattern<T extends string, S extends any, E extends ErrorDetail>(
+  struct: Struct<T, S, E>,
   regexp: RegExp
-): Struct<T, S> {
+): Struct<T, S, E | ValueErrorDetail<T>> {
   return refine(struct, 'pattern', (value) => {
     return (
       regexp.test(value) ||
-      `Expected a ${struct.type} matching \`/${regexp.source}/\` but received "${value}"`
+      ([
+        {
+          class: 'value',
+          except: regexp.source,
+          actually: value,
+          message: `Expected a ${struct.type} matching \`/${regexp.source}/\` but received "${value}"`,
+        },
+      ] as ValueErrorDetail<T>[])
     )
   })
 }
@@ -92,8 +160,14 @@ export function pattern<T extends string, S extends any>(
 
 export function size<
   T extends string | number | Date | any[] | Map<any, any> | Set<any>,
-  S extends any
->(struct: Struct<T, S>, min: number, max: number = min): Struct<T, S> {
+  S extends any,
+  E extends ErrorDetail
+>(
+  struct: Struct<T, S, E>,
+  min: number,
+  max: number = min
+): Struct<T, S, E | SizeErrorDetail<number | Date>> {
+  // todo fix return type
   const expected = `Expected a ${struct.type}`
   const of = min === max ? `of \`${min}\`` : `between \`${min}\` and \`${max}\``
 
@@ -101,19 +175,49 @@ export function size<
     if (typeof value === 'number' || value instanceof Date) {
       return (
         (min <= value && value <= max) ||
-        `${expected} ${of} but received \`${value}\``
+        ([
+          {
+            class: 'size',
+            actually: value,
+            min,
+            max,
+            minExlusive: false,
+            maxExlusive: false,
+            message: `${expected} ${of} but received \`${value}\``,
+          },
+        ] as SizeErrorDetail<number | Date>[])
       )
     } else if (value instanceof Map || value instanceof Set) {
       const { size } = value
       return (
         (min <= size && size <= max) ||
-        `${expected} with a size ${of} but received one with a size of \`${size}\``
+        ([
+          {
+            class: 'size',
+            actually: value,
+            min,
+            max,
+            minExlusive: false,
+            maxExlusive: false,
+            message: `${expected} with a size ${of} but received one with a size of \`${size}\``,
+          },
+        ] as SizeErrorDetail<number | Date>[])
       )
     } else {
       const { length } = value as string | any[]
       return (
         (min <= length && length <= max) ||
-        `${expected} with a length ${of} but received one with a length of \`${length}\``
+        ([
+          {
+            class: 'size',
+            actually: value,
+            min,
+            max,
+            minExlusive: false,
+            maxExlusive: false,
+            message: `${expected} with a length ${of} but received one with a length of \`${length}\``,
+          },
+        ] as SizeErrorDetail<number | Date>[])
       )
     }
   })
@@ -127,17 +231,20 @@ export function size<
  * allows you to layer additional validation on top of existing structs.
  */
 
-export function refine<T, S>(
-  struct: Struct<T, S>,
+export function refine<T, S, E1 extends ErrorDetail, E2 extends ErrorDetail>(
+  struct: Struct<T, S, E1>,
   name: string,
-  refiner: Refiner<T>
-): Struct<T, S> {
-  return new Struct({
+  refiner: Refiner<T, E2>
+): Struct<T, S, E1 | E2> {
+  return new Struct<T, S, E1 | E2>({
     ...struct,
     *refiner(value, ctx) {
       yield* struct.refiner(value, ctx)
       const result = refiner(value, ctx)
-      const failures = toFailures(result, ctx, struct, value)
+      const failures =
+        result === true || result === undefined
+          ? []
+          : toFailures<T, S, E1 | E2>(result, ctx, struct, value)
 
       for (const failure of failures) {
         yield { ...failure, refinement: name }

--- a/src/structs/refinements.ts
+++ b/src/structs/refinements.ts
@@ -250,9 +250,9 @@ export function refine<T, S>(
     ...struct,
     *refiner(value, ctx) {
       yield* struct.refiner(value, ctx)
-      const result = refiner(value, ctx)
+      let result = refiner(value, ctx)
       if (result === false || typeof result === 'string') {
-        return [
+        result = [
           {
             class: 'generic',
             message: result || 'error',

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -1816,8 +1816,8 @@ export function union(Structs: Struct<any, any, any>[]): any {
             actually: value,
             message,
           } as TypeErrorDetail,
-          failures,
         },
+        ...failures,
       ]
     },
   })

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-redeclare */
+
 import { Struct } from '../struct'
 import { define } from './utilities'
 import {
@@ -9,7 +11,13 @@ import {
   isObject,
   ObjectError,
 } from '../utils'
-import { ValuesErrorDetail, Error,ErrorDetail,TypeErrorDetail, ValueErrorDetail, Failure } from '../error'
+import {
+  ValuesErrorDetail,
+  Error,
+  ErrorDetail,
+  TypeErrorDetail,
+  ValueErrorDetail,
+} from '../error'
 
 /**
  * Ensure that any value passes validation.
@@ -27,9 +35,13 @@ export function any(): Struct<any, null, never> {
  * and it is preferred to using `array(any())`.
  */
 
-export function array<T, E extends Error>(Element: Struct<T, unknown, E>): Struct<T[], T, E | TypeErrorDetail>
+export function array<T, E extends Error>(
+  Element: Struct<T, unknown, E>
+): Struct<T[], T, E | TypeErrorDetail>
 export function array(): Struct<unknown[], undefined, Error | TypeErrorDetail>
-export function array<T, E extends Error>(Element?: Struct<T, unknown, E>): any {
+export function array<T, E extends Error>(
+  Element?: Struct<T, unknown, E>
+): any {
   return new Struct<T, unknown, E | TypeErrorDetail>({
     type: 'array',
     schema: Element,
@@ -44,12 +56,17 @@ export function array<T, E extends Error>(Element?: Struct<T, unknown, E>): any 
       return Array.isArray(value) ? value.slice() : value
     },
     validator(value) {
-      return Array.isArray(value) ? [] : [{
-        class: "type",
-        except: 'array',
-        actually: value,
-        message: `Expected an array value, but received: ${print(value)}`
-      }] as TypeErrorDetail[]
+      return (
+        Array.isArray(value) ||
+        ([
+          {
+            class: 'type',
+            except: 'array',
+            actually: value,
+            message: `Expected an array value, but received: ${print(value)}`,
+          },
+        ] as TypeErrorDetail[])
+      )
     },
   })
 }
@@ -60,11 +77,16 @@ export function array<T, E extends Error>(Element?: Struct<T, unknown, E>): any 
 
 export function boolean(): Struct<boolean, null, TypeErrorDetail> {
   return define('boolean', (value) => {
-    return typeof value === 'boolean' ? [] : [{
-      class: "type",
-      except: 'boolean',
-      actually: value,
-    }] as TypeErrorDetail[]
+    return (
+      typeof value === 'boolean' ||
+      ([
+        {
+          class: 'type',
+          except: 'boolean',
+          actually: value,
+        },
+      ] as TypeErrorDetail[])
+    )
   })
 }
 
@@ -77,11 +99,16 @@ export function boolean(): Struct<boolean, null, TypeErrorDetail> {
 
 export function date(): Struct<Date, null, TypeErrorDetail> {
   return define('date', (value) => {
-    return (value instanceof Date && !isNaN(value.getTime())) ? [] : [{
-      class: "type",
-      except: 'date',
-      actually: value,
-    }] as TypeErrorDetail[]
+    return (
+      (value instanceof Date && !isNaN(value.getTime())) ||
+      ([
+        {
+          class: 'type',
+          except: 'date',
+          actually: value,
+        },
+      ] as TypeErrorDetail[])
+    )
   })
 }
 
@@ -110,12 +137,19 @@ export function enums<T extends number | string>(values: readonly T[]): any {
     type: 'enums',
     schema,
     validator(value) {
-      return values.includes(value as any) ? [] : [{
-        class: 'values',
-        except: values,
-        actually: value,
-        message: `Expected one of \`${description}\`, but received: ${print(value)}`
-      }] as ValuesErrorDetail<T>[]
+      return (
+        values.includes(value as any) ||
+        ([
+          {
+            class: 'values',
+            except: values,
+            actually: value,
+            message: `Expected one of \`${description}\`, but received: ${print(
+              value
+            )}`,
+          },
+        ] as ValuesErrorDetail<T>[])
+      )
     },
   })
 }
@@ -127,12 +161,15 @@ export function enums<T extends number | string>(values: readonly T[]): any {
 export function func(): Struct<Function, null, TypeErrorDetail> {
   return define('func', (value) => {
     return (
-      typeof value === 'function' ? [] : [{
-        class:'type',
-        except: 'funciton',
-        actually: value,
-        message: `Expected a function, but received: ${print(value)}`
-      }] as TypeErrorDetail[]
+      typeof value === 'function' ||
+      ([
+        {
+          class: 'type',
+          except: 'funciton',
+          actually: value,
+          message: `Expected a function, but received: ${print(value)}`,
+        },
+      ] as TypeErrorDetail[])
     )
   })
 }
@@ -146,13 +183,17 @@ export function instance<T extends { new (...args: any): any }>(
 ): Struct<InstanceType<T>, null, TypeErrorDetail> {
   return define('instance', (value) => {
     return (
-      value instanceof Class ? [] : [{
-        class: 'type',
-        varidator: 'instance',
-        except: Class.name,
-        actually: value,
-        message: `Expected a \`${Class.name}\` instance, but received: ${print(value)}`
-      }]
+      value instanceof Class || [
+        {
+          class: 'type',
+          varidator: 'instance',
+          except: Class.name,
+          actually: value,
+          message: `Expected a \`${
+            Class.name
+          }\` instance, but received: ${print(value)}`,
+        },
+      ]
     )
   })
 }
@@ -164,12 +205,16 @@ export function instance<T extends { new (...args: any): any }>(
 export function integer(): Struct<number, null, TypeErrorDetail> {
   return define('integer', (value) => {
     return (
-      (typeof value === 'number' && !isNaN(value) && Number.isInteger(value)) ? [] : [{
-        class: 'type',
-        except: 'number',
-        actually: value,
-        message: `Expected an integer, but received: ${print(value)}`,
-      }]
+      (typeof value === 'number' &&
+        !isNaN(value) &&
+        Number.isInteger(value)) || [
+        {
+          class: 'type',
+          except: 'number',
+          actually: value,
+          message: `Expected an integer, but received: ${print(value)}`,
+        },
+      ]
     )
   })
 }
@@ -178,7 +223,9 @@ export function integer(): Struct<number, null, TypeErrorDetail> {
  * Ensure that a value matches all of a set of types.
  */
 
-export function intersection<A>(Structs: TupleSchema<[A]>): Struct<A, null, Error> // todo
+export function intersection<A>(
+  Structs: TupleSchema<[A]>
+): Struct<A, null, Error> // todo
 export function intersection<A, B>(
   Structs: TupleSchema<[A, B]>
 ): Struct<A & B, null, Error>
@@ -220,15 +267,24 @@ export function intersection<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(
 ): Struct<A & B & C & D & E & F & G & H & I & J & K & L & M & N, null, Error>
 export function intersection<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(
   Structs: TupleSchema<[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]>
-): Struct<A & B & C & D & E & F & G & H & I & J & K & L & M & N & O, null, Error>
+): Struct<
+  A & B & C & D & E & F & G & H & I & J & K & L & M & N & O,
+  null,
+  Error
+>
 export function intersection<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
   Structs: TupleSchema<[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]>
-): Struct<A & B & C & D & E & F & G & H & I & J & K & L & M & N & O & P, null, Error>
+): Struct<
+  A & B & C & D & E & F & G & H & I & J & K & L & M & N & O & P,
+  null,
+  Error
+>
 export function intersection<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(
   Structs: TupleSchema<[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]>
 ): Struct<
   A & B & C & D & E & F & G & H & I & J & K & L & M & N & O & P & Q,
-  null, Error
+  null,
+  Error
 >
 export function intersection(Structs: Array<Struct<any, any, Error>>): any {
   return new Struct({
@@ -256,20 +312,31 @@ export function intersection(Structs: Array<Struct<any, any, Error>>): any {
  * Ensure that a value is an exact value, using `===` for comparison.
  */
 
-export function literal<T extends boolean>(constant: T): Struct<T, null, ValueErrorDetail<T>>
-export function literal<T extends number>(constant: T): Struct<T, null, ValueErrorDetail<T>>
-export function literal<T extends string>(constant: T): Struct<T, null, ValueErrorDetail<T>>
+export function literal<T extends boolean>(
+  constant: T
+): Struct<T, null, ValueErrorDetail<T>>
+export function literal<T extends number>(
+  constant: T
+): Struct<T, null, ValueErrorDetail<T>>
+export function literal<T extends string>(
+  constant: T
+): Struct<T, null, ValueErrorDetail<T>>
 export function literal<T>(constant: T): Struct<T, null, ValueErrorDetail<T>>
 export function literal<T>(constant: T): any {
   const description = print(constant)
   return define('literal', (value) => {
     return (
-      value === constant ? [] : [{
-        class: 'value',
-        except: constant,
-        actually: value,
-        message: `Expected the literal \`${description}\`, but received: ${print(value)}`,
-      }] as ValueErrorDetail<T>[]
+      value === constant ||
+      ([
+        {
+          class: 'value',
+          except: constant,
+          actually: value,
+          message: `Expected the literal \`${description}\`, but received: ${print(
+            value
+          )}`,
+        },
+      ] as ValueErrorDetail<T>[])
     )
   })
 }
@@ -284,7 +351,10 @@ export function map<K, V, KE extends Error, VE extends Error>(
   Key: Struct<K, unknown, KE>,
   Value: Struct<V, unknown, VE>
 ): Struct<Map<K, V>, null, TypeErrorDetail | KE | VE>
-export function map<K, V>(Key?: Struct<K, unknown, any>, Value?: Struct<V, unknown, any>): any {
+export function map<K, V>(
+  Key?: Struct<K, unknown, any>,
+  Value?: Struct<V, unknown, any>
+): any {
   return new Struct({
     type: 'map',
     schema: null,
@@ -301,12 +371,15 @@ export function map<K, V>(Key?: Struct<K, unknown, any>, Value?: Struct<V, unkno
     },
     validator(value) {
       return (
-        value instanceof Map ? [] : [{
-          class: 'type',
-          except: 'Map',
-          actually: value,
-          message: `Expected a \`Map\` object, but received: ${print(value)}`,
-        }] as TypeErrorDetail[]
+        value instanceof Map ||
+        ([
+          {
+            class: 'type',
+            except: 'Map',
+            actually: value,
+            message: `Expected a \`Map\` object, but received: ${print(value)}`,
+          },
+        ] as TypeErrorDetail[])
       )
     },
   })
@@ -317,22 +390,28 @@ export function map<K, V>(Key?: Struct<K, unknown, any>, Value?: Struct<V, unkno
  */
 
 export function never(): Struct<never, null, TypeErrorDetail> {
-  return define('never', value => [{
-    class: 'type',
-    except: 'never',
-    actually: value
-  }] as TypeErrorDetail[])
+  return define('never', (value) =>
+    [
+      {
+        class: 'type',
+        except: 'never',
+        actually: value,
+      },
+    ] as TypeErrorDetail[])
 }
 
 /**
  * Augment an existing struct to allow `null` values.
  */
 
-export function nullable<T, S, E extends ErrorDetail>(struct: Struct<T, S, E>): Struct<T | null, S, E> {
+export function nullable<T, S, E extends ErrorDetail>(
+  struct: Struct<T, S, E>
+): Struct<T | null, S, E> {
   return new Struct({
     ...struct,
-    validator: (value, ctx) => value === null ? [] : struct.validator(value, ctx),
-    refiner: (value, ctx) => value === null ? [] : struct.refiner(value, ctx),
+    validator: (value, ctx) =>
+      value === null ? [] : struct.validator(value, ctx),
+    refiner: (value, ctx) => (value === null ? [] : struct.refiner(value, ctx)),
   })
 }
 
@@ -343,12 +422,15 @@ export function nullable<T, S, E extends ErrorDetail>(struct: Struct<T, S, E>): 
 export function number(): Struct<number, null, TypeErrorDetail> {
   return define('number', (value) => {
     return (
-      (typeof value === 'number' && !isNaN(value)) ? [] : [{
-        class: 'type',
-        except: 'number',
-        actually: value,
-        message: `Expected a number, but received: ${print(value)}`,
-      }] as TypeErrorDetail[]
+      (typeof value === 'number' && !isNaN(value)) ||
+      ([
+        {
+          class: 'type',
+          except: 'number',
+          actually: value,
+          message: `Expected a number, but received: ${print(value)}`,
+        },
+      ] as TypeErrorDetail[])
     )
   })
 }
@@ -386,12 +468,15 @@ export function object<S extends ObjectSchema>(schema?: S): any {
     },
     validator(value) {
       return (
-        isObject(value) ? [] : [{
-          class: 'type',
-          except: 'object',
-          actually: value,
-          message: `Expected an object, but received: ${print(value)}`
-        }] as TypeErrorDetail[]
+        isObject(value) ||
+        ([
+          {
+            class: 'type',
+            except: 'object',
+            actually: value,
+            message: `Expected an object, but received: ${print(value)}`,
+          },
+        ] as TypeErrorDetail[])
       )
     },
     coercer(value) {
@@ -404,12 +489,15 @@ export function object<S extends ObjectSchema>(schema?: S): any {
  * Augment a struct to allow `undefined` values.
  */
 
-export function optional<T, S, E extends Error>(struct: Struct<T, S, E>): Struct<T | undefined, S, E> {
+export function optional<T, S, E extends Error>(
+  struct: Struct<T, S, E>
+): Struct<T | undefined, S, E> {
   return new Struct({
     ...struct,
     validator: (value, ctx) =>
       value === undefined ? [] : struct.validator(value, ctx),
-    refiner: (value, ctx) => value === undefined ? [] : struct.refiner(value, ctx),
+    refiner: (value, ctx) =>
+      value === undefined ? [] : struct.refiner(value, ctx),
   })
 }
 
@@ -438,12 +526,15 @@ export function record<K extends string, V, KE extends Error, VE extends Error>(
     },
     validator(value) {
       return (
-        isObject(value) ? [] : [{
-          class: 'type',
-          except: 'object',
-          actually: value,
-          message: `Expected an object, but received: ${print(value)}`
-        }] as TypeErrorDetail[]
+        isObject(value) ||
+        ([
+          {
+            class: 'type',
+            except: 'object',
+            actually: value,
+            message: `Expected an object, but received: ${print(value)}`,
+          },
+        ] as TypeErrorDetail[])
       )
     },
   })
@@ -458,11 +549,16 @@ export function record<K extends string, V, KE extends Error, VE extends Error>(
 
 export function regexp(): Struct<RegExp, null, TypeErrorDetail> {
   return define('regexp', (value) => {
-    return value instanceof RegExp ? [] : [{
-      class: 'type',
-      except:'regexp',
-      actually:value,
-    }] as TypeErrorDetail[]
+    return (
+      value instanceof RegExp ||
+      ([
+        {
+          class: 'type',
+          except: 'regexp',
+          actually: value,
+        },
+      ] as TypeErrorDetail[])
+    )
   })
 }
 
@@ -472,8 +568,12 @@ export function regexp(): Struct<RegExp, null, TypeErrorDetail> {
  */
 
 export function set(): Struct<Set<unknown>, null, Error>
-export function set<T, E extends ErrorDetail>(Element: Struct<T, unknown, E>): Struct<Set<T>, null, E | TypeErrorDetail>
-export function set<T, E extends ErrorDetail>(Element?: Struct<T, unknown, E>): any {
+export function set<T, E extends ErrorDetail>(
+  Element: Struct<T, unknown, E>
+): Struct<Set<T>, null, E | TypeErrorDetail>
+export function set<T, E extends ErrorDetail>(
+  Element?: Struct<T, unknown, E>
+): any {
   return new Struct<T, unknown, E | TypeErrorDetail>({
     type: 'set',
     schema: null,
@@ -489,12 +589,15 @@ export function set<T, E extends ErrorDetail>(Element?: Struct<T, unknown, E>): 
     },
     validator(value) {
       return (
-        value instanceof Set ? [] : [{
-          class: 'type',
-          except: 'Set',
-          actually: value,
-          message: `Expected a \`Set\` object, but received: ${print(value)}`
-        }] as TypeErrorDetail[]
+        value instanceof Set ||
+        ([
+          {
+            class: 'type',
+            except: 'Set',
+            actually: value,
+            message: `Expected a \`Set\` object, but received: ${print(value)}`,
+          },
+        ] as TypeErrorDetail[])
       )
     },
   })
@@ -507,12 +610,15 @@ export function set<T, E extends ErrorDetail>(Element?: Struct<T, unknown, E>): 
 export function string(): Struct<string, null, TypeErrorDetail> {
   return define('string', (value) => {
     return (
-      typeof value === 'string' ? [] : [{
-        class: 'type',
-        except: 'string',
-        actually: value,
-        message: `Expected a string, but received: ${print(value)}`
-      }] as TypeErrorDetail[]
+      typeof value === 'string' ||
+      ([
+        {
+          class: 'type',
+          except: 'string',
+          actually: value,
+          message: `Expected a string, but received: ${print(value)}`,
+        },
+      ] as TypeErrorDetail[])
     )
   })
 }
@@ -527,51 +633,587 @@ export function tuple<A, AE extends ErrorDetail>(
 export function tuple<A, B, AE extends ErrorDetail, BE extends ErrorDetail>(
   Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>]
 ): Struct<[A | B], null, AE | BE>
-export function tuple<A, B, C, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>]
+export function tuple<
+  A,
+  B,
+  C,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>
+  ]
 ): Struct<[A | B | C], null, AE | BE | CE>
-export function tuple<A, B, C, D, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>]
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>
+  ]
 ): Struct<[A | B | C | D], null, AE | BE | CE | DE>
-export function tuple<A, B, C, D, E, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>]
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>
+  ]
 ): Struct<[A | B | C | D | E], null, AE | BE | CE | DE | EE>
-export function tuple<A, B, C, D, E, F, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>]
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>
+  ]
 ): Struct<[A | B | C | D | E | F], null, AE | BE | CE | DE | EE | FE>
-export function tuple<A, B, C, D, E, F, G, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>]
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>
+  ]
 ): Struct<[A | B | C | D | E | F | G], null, AE | BE | CE | DE | EE | FE | GE>
-export function tuple<A, B, C, D, E, F, G, H, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>]
-): Struct<[A | B | C | D | E | F | G | H], null, AE | BE | CE | DE | EE | FE | GE | HE>
-export function tuple<A, B, C, D, E, F, G, H, I, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>]
-): Struct<[A | B | C | D | E | F | G | H | I], null, AE | BE | CE | DE | EE | FE | GE | HE | IE>
-export function tuple<A, B, C, D, E, F, G, H, I, J, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE>
-export function tuple<A, B, C, D, E, F, G, H, I, J, K, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE>
-export function tuple<A, B, C, D, E, F, G, H, I, J, K, L, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE>
-export function tuple<A, B, C, D, E, F, G, H, I, J, K, L, M, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME>
-export function tuple<A, B, C, D, E, F, G, H, I, J, K, L, M, N, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE>
-export function tuple<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail, OE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>, Struct<O, unknown, OE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N | O], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE>
-export function tuple<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail, OE extends ErrorDetail, PE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>, Struct<O, unknown, OE>, Struct<P, unknown, PE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE>
-export function tuple<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail, OE extends ErrorDetail, PE extends ErrorDetail, QE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>, Struct<O, unknown, OE>, Struct<P, unknown, PE>, Struct<Q, unknown, QE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE | QE>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail,
+  OE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>,
+    Struct<O, unknown, OE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail,
+  OE extends ErrorDetail,
+  PE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>,
+    Struct<O, unknown, OE>,
+    Struct<P, unknown, PE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE
+>
+export function tuple<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail,
+  OE extends ErrorDetail,
+  PE extends ErrorDetail,
+  QE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>,
+    Struct<O, unknown, OE>,
+    Struct<P, unknown, PE>,
+    Struct<Q, unknown, QE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q],
+  null,
+  | AE
+  | BE
+  | CE
+  | DE
+  | EE
+  | FE
+  | GE
+  | HE
+  | IE
+  | JE
+  | KE
+  | LE
+  | ME
+  | NE
+  | OE
+  | PE
+  | QE
+>
 /*
 // generate script
 var keys = 'A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q'.split(',').map(s=>s.trim());
@@ -600,12 +1242,15 @@ export function tuple(Elements: Struct<any, any, any>[]): any {
     },
     validator(value) {
       return (
-        Array.isArray(value) ? [] : [{
-          class: 'type',
-          except: 'array',
-          actually: value,
-          message: `Expected an array, but received: ${print(value)}`
-        }] as TypeErrorDetail[]
+        Array.isArray(value) ||
+        ([
+          {
+            class: 'type',
+            except: 'array',
+            actually: value,
+            message: `Expected an array, but received: ${print(value)}`,
+          },
+        ] as TypeErrorDetail[])
       )
     },
   })
@@ -634,12 +1279,15 @@ export function type<S extends ObjectSchema>(
     },
     validator(value) {
       return (
-        isObject(value) ? [] : [{
-          class: 'type',
-          except:'object',
-          actually: value,
-          message: `Expected an object, but received: ${print(value)}`,
-        }] as TypeErrorDetail[]
+        isObject(value) ||
+        ([
+          {
+            class: 'type',
+            except: 'object',
+            actually: value,
+            message: `Expected an object, but received: ${print(value)}`,
+          },
+        ] as TypeErrorDetail[])
       )
     },
   })
@@ -654,51 +1302,587 @@ export function union<A, AE extends ErrorDetail>(
 export function union<A, B, AE extends ErrorDetail, BE extends ErrorDetail>(
   Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>]
 ): Struct<[A | B], null, AE | BE>
-export function union<A, B, C, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>]
+export function union<
+  A,
+  B,
+  C,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>
+  ]
 ): Struct<[A | B | C], null, AE | BE | CE>
-export function union<A, B, C, D, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>]
+export function union<
+  A,
+  B,
+  C,
+  D,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>
+  ]
 ): Struct<[A | B | C | D], null, AE | BE | CE | DE>
-export function union<A, B, C, D, E, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>]
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>
+  ]
 ): Struct<[A | B | C | D | E], null, AE | BE | CE | DE | EE>
-export function union<A, B, C, D, E, F, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>]
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>
+  ]
 ): Struct<[A | B | C | D | E | F], null, AE | BE | CE | DE | EE | FE>
-export function union<A, B, C, D, E, F, G, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>]
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>
+  ]
 ): Struct<[A | B | C | D | E | F | G], null, AE | BE | CE | DE | EE | FE | GE>
-export function union<A, B, C, D, E, F, G, H, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>]
-): Struct<[A | B | C | D | E | F | G | H], null, AE | BE | CE | DE | EE | FE | GE | HE>
-export function union<A, B, C, D, E, F, G, H, I, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>]
-): Struct<[A | B | C | D | E | F | G | H | I], null, AE | BE | CE | DE | EE | FE | GE | HE | IE>
-export function union<A, B, C, D, E, F, G, H, I, J, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE>
-export function union<A, B, C, D, E, F, G, H, I, J, K, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE>
-export function union<A, B, C, D, E, F, G, H, I, J, K, L, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE>
-export function union<A, B, C, D, E, F, G, H, I, J, K, L, M, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME>
-export function union<A, B, C, D, E, F, G, H, I, J, K, L, M, N, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE>
-export function union<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail, OE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>, Struct<O, unknown, OE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N | O], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE>
-export function union<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail, OE extends ErrorDetail, PE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>, Struct<O, unknown, OE>, Struct<P, unknown, PE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE>
-export function union<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, AE extends ErrorDetail, BE extends ErrorDetail, CE extends ErrorDetail, DE extends ErrorDetail, EE extends ErrorDetail, FE extends ErrorDetail, GE extends ErrorDetail, HE extends ErrorDetail, IE extends ErrorDetail, JE extends ErrorDetail, KE extends ErrorDetail, LE extends ErrorDetail, ME extends ErrorDetail, NE extends ErrorDetail, OE extends ErrorDetail, PE extends ErrorDetail, QE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>, Struct<C, unknown, CE>, Struct<D, unknown, DE>, Struct<E, unknown, EE>, Struct<F, unknown, FE>, Struct<G, unknown, GE>, Struct<H, unknown, HE>, Struct<I, unknown, IE>, Struct<J, unknown, JE>, Struct<K, unknown, KE>, Struct<L, unknown, LE>, Struct<M, unknown, ME>, Struct<N, unknown, NE>, Struct<O, unknown, OE>, Struct<P, unknown, PE>, Struct<Q, unknown, QE>]
-): Struct<[A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q], null, AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE | QE>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail,
+  OE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>,
+    Struct<O, unknown, OE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail,
+  OE extends ErrorDetail,
+  PE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>,
+    Struct<O, unknown, OE>,
+    Struct<P, unknown, PE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P],
+  null,
+  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE
+>
+export function union<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  AE extends ErrorDetail,
+  BE extends ErrorDetail,
+  CE extends ErrorDetail,
+  DE extends ErrorDetail,
+  EE extends ErrorDetail,
+  FE extends ErrorDetail,
+  GE extends ErrorDetail,
+  HE extends ErrorDetail,
+  IE extends ErrorDetail,
+  JE extends ErrorDetail,
+  KE extends ErrorDetail,
+  LE extends ErrorDetail,
+  ME extends ErrorDetail,
+  NE extends ErrorDetail,
+  OE extends ErrorDetail,
+  PE extends ErrorDetail,
+  QE extends ErrorDetail
+>(
+  Structs: [
+    Struct<A, unknown, AE>,
+    Struct<B, unknown, BE>,
+    Struct<C, unknown, CE>,
+    Struct<D, unknown, DE>,
+    Struct<E, unknown, EE>,
+    Struct<F, unknown, FE>,
+    Struct<G, unknown, GE>,
+    Struct<H, unknown, HE>,
+    Struct<I, unknown, IE>,
+    Struct<J, unknown, JE>,
+    Struct<K, unknown, KE>,
+    Struct<L, unknown, LE>,
+    Struct<M, unknown, ME>,
+    Struct<N, unknown, NE>,
+    Struct<O, unknown, OE>,
+    Struct<P, unknown, PE>,
+    Struct<Q, unknown, QE>
+  ]
+): Struct<
+  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q],
+  null,
+  | AE
+  | BE
+  | CE
+  | DE
+  | EE
+  | FE
+  | GE
+  | HE
+  | IE
+  | JE
+  | KE
+  | LE
+  | ME
+  | NE
+  | OE
+  | PE
+  | QE
+>
 /*
 // generate script
 var keys = 'A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q'.split(',').map(s=>s.trim());
@@ -735,9 +1919,10 @@ export function union(Structs: Struct<any, any, any>[]): any {
 
       const message = `Expected the value to satisfy a union of \`${description}\`, but received: ${print(
         value
-      )}`;
-      return [{
-          value: value,
+      )}`
+      return [
+        {
+          value,
           key: ctx.path[ctx.path.length - 1],
           type: 'union',
           refinement: undefined,
@@ -748,10 +1933,11 @@ export function union(Structs: Struct<any, any, any>[]): any {
             class: 'type',
             except: description,
             actually: value,
-            message
+            message,
           } as TypeErrorDetail,
           failures,
-      }]
+        },
+      ]
     },
   })
 }

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-redeclare */
 
-import { Infer, Struct } from '../struct'
+import { Infer, InferError, Struct } from '../struct'
 import { define } from './utilities'
 import {
   TupleSchema,
@@ -35,14 +35,12 @@ export function any(): Struct<any, null, never> {
  * and it is preferred to using `array(any())`.
  */
 
-export function array<E extends ErrorDetail, T extends Struct<any, any, E>>(
+export function array<T extends Struct<any, any, any>>(
   Element: T
-): Struct<Infer<T>[], T, E>
+): Struct<Infer<T>[], T, InferError<T> | TypeErrorDetail>
 export function array(): Struct<unknown[], undefined, any>
-export function array<T, E extends Error>(
-  Element?: Struct<T, unknown, E>
-): any {
-  return new Struct<T, unknown, E | TypeErrorDetail>({
+export function array<T>(Element?: Struct<T, unknown, any>): any {
+  return new Struct<T, unknown, ErrorDetail>({
     type: 'array',
     schema: Element,
     *entries(value) {
@@ -626,599 +624,554 @@ export function string(): Struct<string, null, TypeErrorDetail> {
 /**
  * Ensure that a value is a tuple of a specific length, and that each of its
  * elements is of a specific type.
- */
-export function tuple<A, AE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>]
-): Struct<[A], null, AE>
-export function tuple<A, B, AE extends ErrorDetail, BE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>]
-): Struct<[A, B], null, AE | BE>
+ */ export function tuple<A extends Struct<any, any, Error>>(
+  Structs: [A]
+): Struct<[Infer<A>], null, InferError<A>>
 export function tuple<
-  A,
-  B,
-  C,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>
-  ]
-): Struct<[A, B, C], null, AE | BE | CE>
+  Structs: [A, B]
+): Struct<[Infer<A>, Infer<B>], null, InferError<A> | InferError<B>>
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>
-  ]
-): Struct<[A, B, C, D], null, AE | BE | CE | DE>
-export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>
-  ]
-): Struct<[A, B, C, D, E], null, AE | BE | CE | DE | EE>
-export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>
-  ]
-): Struct<[A, B, C, D, E, F], null, AE | BE | CE | DE | EE | FE>
-export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>
-  ]
-): Struct<[A, B, C, D, E, F, G], null, AE | BE | CE | DE | EE | FE | GE>
-export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>
-  ]
-): Struct<[A, B, C, D, E, F, G, H], null, AE | BE | CE | DE | EE | FE | GE | HE>
-export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>
-  ]
+  Structs: [A, B, C]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I],
+  [Infer<A>, Infer<B>, Infer<C>],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE
+  InferError<A> | InferError<B> | InferError<C>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>
-  ]
+  Structs: [A, B, C, D]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J],
+  [Infer<A>, Infer<B>, Infer<C>, Infer<D>],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE
+  InferError<A> | InferError<B> | InferError<C> | InferError<D>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>
-  ]
+  Structs: [A, B, C, D, E]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J, K],
+  [Infer<A>, Infer<B>, Infer<C>, Infer<D>, Infer<E>],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE
+  InferError<A> | InferError<B> | InferError<C> | InferError<D> | InferError<E>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>
-  ]
+  Structs: [A, B, C, D, E, F]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J, K, L],
+  [Infer<A>, Infer<B>, Infer<C>, Infer<D>, Infer<E>, Infer<F>],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>
-  ]
+  Structs: [A, B, C, D, E, F, G]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J, K, L, M],
+  [Infer<A>, Infer<B>, Infer<C>, Infer<D>, Infer<E>, Infer<F>, Infer<G>],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J, K, L, M, N],
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>
+  ],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail,
-  OE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>,
-    Struct<O, unknown, OE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H, I]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O],
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>
+  ],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  P,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail,
-  OE extends ErrorDetail,
-  PE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>,
-    Struct<O, unknown, OE>,
-    Struct<P, unknown, PE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H, I, J]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P],
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>
+  ],
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
 >
 export function tuple<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  P,
-  Q,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail,
-  OE extends ErrorDetail,
-  PE extends ErrorDetail,
-  QE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>,
-    Struct<O, unknown, OE>,
-    Struct<P, unknown, PE>,
-    Struct<Q, unknown, QE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H, I, J, K]
 ): Struct<
-  [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q],
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>,
+    Infer<K>
+  ],
   null,
-  | AE
-  | BE
-  | CE
-  | DE
-  | EE
-  | FE
-  | GE
-  | HE
-  | IE
-  | JE
-  | KE
-  | LE
-  | ME
-  | NE
-  | OE
-  | PE
-  | QE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+>
+export function tuple<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L]
+): Struct<
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>,
+    Infer<K>,
+    Infer<L>
+  ],
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+>
+export function tuple<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M]
+): Struct<
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>,
+    Infer<K>,
+    Infer<L>,
+    Infer<M>
+  ],
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+>
+export function tuple<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+): Struct<
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>,
+    Infer<K>,
+    Infer<L>,
+    Infer<M>,
+    Infer<N>
+  ],
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+>
+export function tuple<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>,
+  O extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+): Struct<
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>,
+    Infer<K>,
+    Infer<L>,
+    Infer<M>,
+    Infer<N>,
+    Infer<O>
+  ],
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+  | InferError<O>
+>
+export function tuple<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>,
+  O extends Struct<any, any, Error>,
+  P extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+): Struct<
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>,
+    Infer<K>,
+    Infer<L>,
+    Infer<M>,
+    Infer<N>,
+    Infer<O>,
+    Infer<P>
+  ],
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+  | InferError<O>
+  | InferError<P>
+>
+export function tuple<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>,
+  O extends Struct<any, any, Error>,
+  P extends Struct<any, any, Error>,
+  Q extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+): Struct<
+  [
+    Infer<A>,
+    Infer<B>,
+    Infer<C>,
+    Infer<D>,
+    Infer<E>,
+    Infer<F>,
+    Infer<G>,
+    Infer<H>,
+    Infer<I>,
+    Infer<J>,
+    Infer<K>,
+    Infer<L>,
+    Infer<M>,
+    Infer<N>,
+    Infer<O>,
+    Infer<P>,
+    Infer<Q>
+  ],
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+  | InferError<O>
+  | InferError<P>
+  | InferError<Q>
 >
 /*
 // generate script
 var keys = 'A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q'.split(',').map(s=>s.trim());
 keys.map((v,i) => {
   const types = keys.slice(0, i+1);
-  const errors = types.map(t => `${t}E extends ErrorDetail`);
-  return `export function tuple<${types.join(', ')}, ${errors.join(', ')}>(
-  Structs: [${types.map(t => `Struct<${t}, unknown, ${t}E>`).join(', ')}]
-): Struct<[${types.join(', ')}], null, ${types.map(t => t+'E').join(' | ')}>`;
+  return `export function tuple<${types.map(t => `${t} extends Struct<any,any,Error>`).join(', ')}>(
+  Structs: [${types.join(', ')}]
+): Struct<[${types.map(t => `Infer<${t}>`).join(', ')}], null, ${types.map(t => `InferError<${t}>`).join(' | ')}>`;
 }).join('\n')
 */
 export function tuple(Elements: Struct<any, any, any>[]): any {
@@ -1292,602 +1245,534 @@ export function type<S extends ObjectSchema>(
 /**
  * Ensure that a value matches one of a set of types.
  */
-export function union<A, AE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>]
-): Struct<A, null, AE>
-export function union<A, B, AE extends ErrorDetail, BE extends ErrorDetail>(
-  Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>]
-): Struct<A | B, null, AE | BE>
+export function union<A extends Struct<any, any, Error>>(
+  Structs: [A]
+): Struct<Infer<A>, null, InferError<A>>
 export function union<
-  A,
-  B,
-  C,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>
-  ]
-): Struct<A | B | C, null, AE | BE | CE>
+  Structs: [A, B]
+): Struct<Infer<A> | Infer<B>, null, InferError<A> | InferError<B>>
 export function union<
-  A,
-  B,
-  C,
-  D,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>
-  ]
-): Struct<A | B | C | D, null, AE | BE | CE | DE>
-export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>
-  ]
-): Struct<A | B | C | D | E, null, AE | BE | CE | DE | EE>
-export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>
-  ]
-): Struct<A | B | C | D | E | F, null, AE | BE | CE | DE | EE | FE>
-export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>
-  ]
-): Struct<A | B | C | D | E | F | G, null, AE | BE | CE | DE | EE | FE | GE>
-export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail
->(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>
-  ]
+  Structs: [A, B, C]
 ): Struct<
-  A | B | C | D | E | F | G | H,
+  Infer<A> | Infer<B> | Infer<C>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE
+  InferError<A> | InferError<B> | InferError<C>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>
-  ]
+  Structs: [A, B, C, D]
 ): Struct<
-  A | B | C | D | E | F | G | H | I,
+  Infer<A> | Infer<B> | Infer<C> | Infer<D>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE
+  InferError<A> | InferError<B> | InferError<C> | InferError<D>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>
-  ]
+  Structs: [A, B, C, D, E]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J,
+  Infer<A> | Infer<B> | Infer<C> | Infer<D> | Infer<E>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE
+  InferError<A> | InferError<B> | InferError<C> | InferError<D> | InferError<E>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>
-  ]
+  Structs: [A, B, C, D, E, F]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J | K,
+  Infer<A> | Infer<B> | Infer<C> | Infer<D> | Infer<E> | Infer<F>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>
-  ]
+  Structs: [A, B, C, D, E, F, G]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J | K | L,
+  Infer<A> | Infer<B> | Infer<C> | Infer<D> | Infer<E> | Infer<F> | Infer<G>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>
-  ]
+  Structs: [A, B, C, D, E, F, G, H]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J | K | L | M,
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H, I]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J | K | L | M | N,
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail,
-  OE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>,
-    Struct<O, unknown, OE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H, I, J]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J | K | L | M | N | O,
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  P,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail,
-  OE extends ErrorDetail,
-  PE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>,
-    Struct<O, unknown, OE>,
-    Struct<P, unknown, PE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H, I, J, K]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P,
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>
+  | Infer<K>,
   null,
-  AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
 >
 export function union<
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  P,
-  Q,
-  AE extends ErrorDetail,
-  BE extends ErrorDetail,
-  CE extends ErrorDetail,
-  DE extends ErrorDetail,
-  EE extends ErrorDetail,
-  FE extends ErrorDetail,
-  GE extends ErrorDetail,
-  HE extends ErrorDetail,
-  IE extends ErrorDetail,
-  JE extends ErrorDetail,
-  KE extends ErrorDetail,
-  LE extends ErrorDetail,
-  ME extends ErrorDetail,
-  NE extends ErrorDetail,
-  OE extends ErrorDetail,
-  PE extends ErrorDetail,
-  QE extends ErrorDetail
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>
 >(
-  Structs: [
-    Struct<A, unknown, AE>,
-    Struct<B, unknown, BE>,
-    Struct<C, unknown, CE>,
-    Struct<D, unknown, DE>,
-    Struct<E, unknown, EE>,
-    Struct<F, unknown, FE>,
-    Struct<G, unknown, GE>,
-    Struct<H, unknown, HE>,
-    Struct<I, unknown, IE>,
-    Struct<J, unknown, JE>,
-    Struct<K, unknown, KE>,
-    Struct<L, unknown, LE>,
-    Struct<M, unknown, ME>,
-    Struct<N, unknown, NE>,
-    Struct<O, unknown, OE>,
-    Struct<P, unknown, PE>,
-    Struct<Q, unknown, QE>
-  ]
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L]
 ): Struct<
-  A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q,
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>
+  | Infer<K>
+  | Infer<L>,
   null,
-  | AE
-  | BE
-  | CE
-  | DE
-  | EE
-  | FE
-  | GE
-  | HE
-  | IE
-  | JE
-  | KE
-  | LE
-  | ME
-  | NE
-  | OE
-  | PE
-  | QE
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+>
+export function union<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M]
+): Struct<
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>
+  | Infer<K>
+  | Infer<L>
+  | Infer<M>,
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+>
+export function union<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+): Struct<
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>
+  | Infer<K>
+  | Infer<L>
+  | Infer<M>
+  | Infer<N>,
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+>
+export function union<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>,
+  O extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+): Struct<
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>
+  | Infer<K>
+  | Infer<L>
+  | Infer<M>
+  | Infer<N>
+  | Infer<O>,
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+  | InferError<O>
+>
+export function union<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>,
+  O extends Struct<any, any, Error>,
+  P extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+): Struct<
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>
+  | Infer<K>
+  | Infer<L>
+  | Infer<M>
+  | Infer<N>
+  | Infer<O>
+  | Infer<P>,
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+  | InferError<O>
+  | InferError<P>
+>
+export function union<
+  A extends Struct<any, any, Error>,
+  B extends Struct<any, any, Error>,
+  C extends Struct<any, any, Error>,
+  D extends Struct<any, any, Error>,
+  E extends Struct<any, any, Error>,
+  F extends Struct<any, any, Error>,
+  G extends Struct<any, any, Error>,
+  H extends Struct<any, any, Error>,
+  I extends Struct<any, any, Error>,
+  J extends Struct<any, any, Error>,
+  K extends Struct<any, any, Error>,
+  L extends Struct<any, any, Error>,
+  M extends Struct<any, any, Error>,
+  N extends Struct<any, any, Error>,
+  O extends Struct<any, any, Error>,
+  P extends Struct<any, any, Error>,
+  Q extends Struct<any, any, Error>
+>(
+  Structs: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+): Struct<
+  | Infer<A>
+  | Infer<B>
+  | Infer<C>
+  | Infer<D>
+  | Infer<E>
+  | Infer<F>
+  | Infer<G>
+  | Infer<H>
+  | Infer<I>
+  | Infer<J>
+  | Infer<K>
+  | Infer<L>
+  | Infer<M>
+  | Infer<N>
+  | Infer<O>
+  | Infer<P>
+  | Infer<Q>,
+  null,
+  | InferError<A>
+  | InferError<B>
+  | InferError<C>
+  | InferError<D>
+  | InferError<E>
+  | InferError<F>
+  | InferError<G>
+  | InferError<H>
+  | InferError<I>
+  | InferError<J>
+  | InferError<K>
+  | InferError<L>
+  | InferError<M>
+  | InferError<N>
+  | InferError<O>
+  | InferError<P>
+  | InferError<Q>
 >
 /*
 // generate script
 var keys = 'A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q'.split(',').map(s=>s.trim());
 keys.map((v,i) => {
   const types = keys.slice(0, i+1);
-  const errors = types.map(t => `${t}E extends ErrorDetail`);
-  return `export function union<${types.join(', ')}, ${errors.join(', ')}>(
-  Structs: [${types.map(t => `Struct<${t}, unknown, ${t}E>`).join(', ')}]
-): Struct<${types.join(' | ')}, null, ${types.map(t => t+'E').join(' | ')}>`;
+  return `export function union<${types.map(t => `${t} extends Struct<any,any,Error>`).join(', ')}>(
+  Structs: [${types.join(', ')}]
+): Struct<${types.map(t => `Infer<${t}>`).join(' | ')}, null, ${types.map(t => `InferError<${t}>`).join(' | ')}>`;
 }).join('\n')
 */
 export function union(Structs: Struct<any, any, any>[]): any {

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-redeclare */
 
-import { Struct } from '../struct'
+import { Infer, Struct } from '../struct'
 import { define } from './utilities'
 import {
   TupleSchema,
@@ -35,10 +35,10 @@ export function any(): Struct<any, null, never> {
  * and it is preferred to using `array(any())`.
  */
 
-export function array<T, E extends Error>(
-  Element: Struct<T, unknown, E>
-): Struct<T[], T, E | TypeErrorDetail>
-export function array(): Struct<unknown[], undefined, Error | TypeErrorDetail>
+export function array<E extends ErrorDetail, T extends Struct<any, any, E>>(
+  Element: T
+): Struct<Infer<T>[], T, E>
+export function array(): Struct<unknown[], undefined, any>
 export function array<T, E extends Error>(
   Element?: Struct<T, unknown, E>
 ): any {
@@ -632,7 +632,7 @@ export function tuple<A, AE extends ErrorDetail>(
 ): Struct<[A], null, AE>
 export function tuple<A, B, AE extends ErrorDetail, BE extends ErrorDetail>(
   Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>]
-): Struct<[A | B], null, AE | BE>
+): Struct<[A, B], null, AE | BE>
 export function tuple<
   A,
   B,
@@ -646,7 +646,7 @@ export function tuple<
     Struct<B, unknown, BE>,
     Struct<C, unknown, CE>
   ]
-): Struct<[A | B | C], null, AE | BE | CE>
+): Struct<[A, B, C], null, AE | BE | CE>
 export function tuple<
   A,
   B,
@@ -663,7 +663,7 @@ export function tuple<
     Struct<C, unknown, CE>,
     Struct<D, unknown, DE>
   ]
-): Struct<[A | B | C | D], null, AE | BE | CE | DE>
+): Struct<[A, B, C, D], null, AE | BE | CE | DE>
 export function tuple<
   A,
   B,
@@ -683,7 +683,7 @@ export function tuple<
     Struct<D, unknown, DE>,
     Struct<E, unknown, EE>
   ]
-): Struct<[A | B | C | D | E], null, AE | BE | CE | DE | EE>
+): Struct<[A, B, C, D, E], null, AE | BE | CE | DE | EE>
 export function tuple<
   A,
   B,
@@ -706,7 +706,7 @@ export function tuple<
     Struct<E, unknown, EE>,
     Struct<F, unknown, FE>
   ]
-): Struct<[A | B | C | D | E | F], null, AE | BE | CE | DE | EE | FE>
+): Struct<[A, B, C, D, E, F], null, AE | BE | CE | DE | EE | FE>
 export function tuple<
   A,
   B,
@@ -732,7 +732,7 @@ export function tuple<
     Struct<F, unknown, FE>,
     Struct<G, unknown, GE>
   ]
-): Struct<[A | B | C | D | E | F | G], null, AE | BE | CE | DE | EE | FE | GE>
+): Struct<[A, B, C, D, E, F, G], null, AE | BE | CE | DE | EE | FE | GE>
 export function tuple<
   A,
   B,
@@ -761,11 +761,7 @@ export function tuple<
     Struct<G, unknown, GE>,
     Struct<H, unknown, HE>
   ]
-): Struct<
-  [A | B | C | D | E | F | G | H],
-  null,
-  AE | BE | CE | DE | EE | FE | GE | HE
->
+): Struct<[A, B, C, D, E, F, G, H], null, AE | BE | CE | DE | EE | FE | GE | HE>
 export function tuple<
   A,
   B,
@@ -798,7 +794,7 @@ export function tuple<
     Struct<I, unknown, IE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I],
+  [A, B, C, D, E, F, G, H, I],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE
 >
@@ -837,7 +833,7 @@ export function tuple<
     Struct<J, unknown, JE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J],
+  [A, B, C, D, E, F, G, H, I, J],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE
 >
@@ -879,7 +875,7 @@ export function tuple<
     Struct<K, unknown, KE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K],
+  [A, B, C, D, E, F, G, H, I, J, K],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE
 >
@@ -924,7 +920,7 @@ export function tuple<
     Struct<L, unknown, LE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L],
+  [A, B, C, D, E, F, G, H, I, J, K, L],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE
 >
@@ -972,7 +968,7 @@ export function tuple<
     Struct<M, unknown, ME>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M],
+  [A, B, C, D, E, F, G, H, I, J, K, L, M],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME
 >
@@ -1023,7 +1019,7 @@ export function tuple<
     Struct<N, unknown, NE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N],
+  [A, B, C, D, E, F, G, H, I, J, K, L, M, N],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE
 >
@@ -1077,7 +1073,7 @@ export function tuple<
     Struct<O, unknown, OE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O],
+  [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE
 >
@@ -1134,7 +1130,7 @@ export function tuple<
     Struct<P, unknown, PE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P],
+  [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P],
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE
 >
@@ -1194,7 +1190,7 @@ export function tuple<
     Struct<Q, unknown, QE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q],
+  [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q],
   null,
   | AE
   | BE
@@ -1222,7 +1218,7 @@ keys.map((v,i) => {
   const errors = types.map(t => `${t}E extends ErrorDetail`);
   return `export function tuple<${types.join(', ')}, ${errors.join(', ')}>(
   Structs: [${types.map(t => `Struct<${t}, unknown, ${t}E>`).join(', ')}]
-): Struct<[${types.join(' | ')}], null, ${types.map(t => t+'E').join(' | ')}>`;
+): Struct<[${types.join(', ')}], null, ${types.map(t => t+'E').join(' | ')}>`;
 }).join('\n')
 */
 export function tuple(Elements: Struct<any, any, any>[]): any {
@@ -1298,10 +1294,10 @@ export function type<S extends ObjectSchema>(
  */
 export function union<A, AE extends ErrorDetail>(
   Structs: [Struct<A, unknown, AE>]
-): Struct<[A], null, AE>
+): Struct<A, null, AE>
 export function union<A, B, AE extends ErrorDetail, BE extends ErrorDetail>(
   Structs: [Struct<A, unknown, AE>, Struct<B, unknown, BE>]
-): Struct<[A | B], null, AE | BE>
+): Struct<A | B, null, AE | BE>
 export function union<
   A,
   B,
@@ -1315,7 +1311,7 @@ export function union<
     Struct<B, unknown, BE>,
     Struct<C, unknown, CE>
   ]
-): Struct<[A | B | C], null, AE | BE | CE>
+): Struct<A | B | C, null, AE | BE | CE>
 export function union<
   A,
   B,
@@ -1332,7 +1328,7 @@ export function union<
     Struct<C, unknown, CE>,
     Struct<D, unknown, DE>
   ]
-): Struct<[A | B | C | D], null, AE | BE | CE | DE>
+): Struct<A | B | C | D, null, AE | BE | CE | DE>
 export function union<
   A,
   B,
@@ -1352,7 +1348,7 @@ export function union<
     Struct<D, unknown, DE>,
     Struct<E, unknown, EE>
   ]
-): Struct<[A | B | C | D | E], null, AE | BE | CE | DE | EE>
+): Struct<A | B | C | D | E, null, AE | BE | CE | DE | EE>
 export function union<
   A,
   B,
@@ -1375,7 +1371,7 @@ export function union<
     Struct<E, unknown, EE>,
     Struct<F, unknown, FE>
   ]
-): Struct<[A | B | C | D | E | F], null, AE | BE | CE | DE | EE | FE>
+): Struct<A | B | C | D | E | F, null, AE | BE | CE | DE | EE | FE>
 export function union<
   A,
   B,
@@ -1401,7 +1397,7 @@ export function union<
     Struct<F, unknown, FE>,
     Struct<G, unknown, GE>
   ]
-): Struct<[A | B | C | D | E | F | G], null, AE | BE | CE | DE | EE | FE | GE>
+): Struct<A | B | C | D | E | F | G, null, AE | BE | CE | DE | EE | FE | GE>
 export function union<
   A,
   B,
@@ -1431,7 +1427,7 @@ export function union<
     Struct<H, unknown, HE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H],
+  A | B | C | D | E | F | G | H,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE
 >
@@ -1467,7 +1463,7 @@ export function union<
     Struct<I, unknown, IE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I],
+  A | B | C | D | E | F | G | H | I,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE
 >
@@ -1506,7 +1502,7 @@ export function union<
     Struct<J, unknown, JE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J],
+  A | B | C | D | E | F | G | H | I | J,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE
 >
@@ -1548,7 +1544,7 @@ export function union<
     Struct<K, unknown, KE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K],
+  A | B | C | D | E | F | G | H | I | J | K,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE
 >
@@ -1593,7 +1589,7 @@ export function union<
     Struct<L, unknown, LE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L],
+  A | B | C | D | E | F | G | H | I | J | K | L,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE
 >
@@ -1641,7 +1637,7 @@ export function union<
     Struct<M, unknown, ME>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M],
+  A | B | C | D | E | F | G | H | I | J | K | L | M,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME
 >
@@ -1692,7 +1688,7 @@ export function union<
     Struct<N, unknown, NE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N],
+  A | B | C | D | E | F | G | H | I | J | K | L | M | N,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE
 >
@@ -1746,7 +1742,7 @@ export function union<
     Struct<O, unknown, OE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O],
+  A | B | C | D | E | F | G | H | I | J | K | L | M | N | O,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE
 >
@@ -1803,7 +1799,7 @@ export function union<
     Struct<P, unknown, PE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P],
+  A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P,
   null,
   AE | BE | CE | DE | EE | FE | GE | HE | IE | JE | KE | LE | ME | NE | OE | PE
 >
@@ -1863,7 +1859,7 @@ export function union<
     Struct<Q, unknown, QE>
   ]
 ): Struct<
-  [A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q],
+  A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q,
   null,
   | AE
   | BE
@@ -1891,7 +1887,7 @@ keys.map((v,i) => {
   const errors = types.map(t => `${t}E extends ErrorDetail`);
   return `export function union<${types.join(', ')}, ${errors.join(', ')}>(
   Structs: [${types.map(t => `Struct<${t}, unknown, ${t}E>`).join(', ')}]
-): Struct<[${types.join(' | ')}], null, ${types.map(t => t+'E').join(' | ')}>`;
+): Struct<${types.join(' | ')}, null, ${types.map(t => t+'E').join(' | ')}>`;
 }).join('\n')
 */
 export function union(Structs: Struct<any, any, any>[]): any {

--- a/src/structs/utilities.ts
+++ b/src/structs/utilities.ts
@@ -1,7 +1,13 @@
 import { Struct, Context, Validator } from '../struct'
 import { object, optional } from './types'
-import { ObjectSchema, Assign, ObjectType, PartialObjectSchema } from '../utils'
-import { Error } from '../error'
+import {
+  ObjectSchema,
+  Assign,
+  ObjectType,
+  PartialObjectSchema,
+  ObjectError,
+} from '../utils'
+import { Error, ErrorDetail, TypeErrorDetail } from '../error'
 
 /**
  * Create a new struct that combines the properties properties from multiple
@@ -10,48 +16,71 @@ import { Error } from '../error'
  * Like JavaScript's `Object.assign` utility.
  */
 
-export function assign<A extends ObjectSchema, B extends ObjectSchema>(
-  A: Struct<ObjectType<A>, A>,
-  B: Struct<ObjectType<B>, B>
-): Struct<ObjectType<Assign<A, B>>, Assign<A, B>>
 export function assign<
   A extends ObjectSchema,
   B extends ObjectSchema,
-  C extends ObjectSchema
+  E1 extends Error,
+  E2 extends Error
 >(
-  A: Struct<ObjectType<A>, A>,
-  B: Struct<ObjectType<B>, B>,
-  C: Struct<ObjectType<C>, C>
-): Struct<ObjectType<Assign<Assign<A, B>, C>>, Assign<Assign<A, B>, C>>
+  A: Struct<ObjectType<A>, A, E1>,
+  B: Struct<ObjectType<B>, B, E2>
+): Struct<ObjectType<Assign<A, B>>, Assign<A, B>, E1 | E2>
 export function assign<
   A extends ObjectSchema,
   B extends ObjectSchema,
   C extends ObjectSchema,
-  D extends ObjectSchema
+  E1 extends Error,
+  E2 extends Error,
+  E3 extends Error
 >(
-  A: Struct<ObjectType<A>, A>,
-  B: Struct<ObjectType<B>, B>,
-  C: Struct<ObjectType<C>, C>,
-  D: Struct<ObjectType<D>, D>
+  A: Struct<ObjectType<A>, A, E1>,
+  B: Struct<ObjectType<B>, B, E2>,
+  C: Struct<ObjectType<C>, C, E3>
 ): Struct<
-  ObjectType<Assign<Assign<Assign<A, B>, C>, D>>,
-  Assign<Assign<Assign<A, B>, C>, D>
+  ObjectType<Assign<Assign<A, B>, C>>,
+  Assign<Assign<A, B>, C>,
+  E1 | E2 | E3
 >
 export function assign<
   A extends ObjectSchema,
   B extends ObjectSchema,
   C extends ObjectSchema,
   D extends ObjectSchema,
-  E extends ObjectSchema
+  E1 extends Error,
+  E2 extends Error,
+  E3 extends Error,
+  E4 extends Error
 >(
-  A: Struct<ObjectType<A>, A>,
-  B: Struct<ObjectType<B>, B>,
-  C: Struct<ObjectType<C>, C>,
-  D: Struct<ObjectType<D>, D>,
-  E: Struct<ObjectType<E>, E>
+  A: Struct<ObjectType<A>, A, E1>,
+  B: Struct<ObjectType<B>, B, E2>,
+  C: Struct<ObjectType<C>, C, E3>,
+  D: Struct<ObjectType<D>, D, E4>
+): Struct<
+  ObjectType<Assign<Assign<Assign<A, B>, C>, D>>,
+  Assign<Assign<Assign<A, B>, C>, D>,
+  E1 | E2 | E3 | E4
+>
+export function assign<
+  A extends ObjectSchema,
+  B extends ObjectSchema,
+  C extends ObjectSchema,
+  D extends ObjectSchema,
+  E extends ObjectSchema,
+  E1 extends Error,
+  E2 extends Error,
+  E3 extends Error,
+  E4 extends Error,
+  E5 extends Error
+>(
+  A: Struct<ObjectType<A>, A, E1>,
+  B: Struct<ObjectType<B>, B, E2>,
+  C: Struct<ObjectType<C>, C, E3>,
+  D: Struct<ObjectType<D>, D, E4>,
+  E: Struct<ObjectType<E>, E, E5>
 ): Struct<
   ObjectType<Assign<Assign<Assign<Assign<A, B>, C>, D>, E>>,
-  Assign<Assign<Assign<Assign<A, B>, C>, D>, E>
+  Assign<Assign<Assign<Assign<A, B>, C>, D>, E>,
+  E1 | E2 | E3 | E4 | E5
 >
 export function assign(...Structs: Struct<any>[]): any {
   const schemas = Structs.map((s) => s.schema)
@@ -78,9 +107,9 @@ export function define<T, E extends Error>(
  * validation logic that changes based on its input.
  */
 
-export function dynamic<T>(
-  fn: (value: unknown, ctx: Context) => Struct<T, any>
-): Struct<T, null> {
+export function dynamic<T, E extends Error>(
+  fn: (value: unknown, ctx: Context) => Struct<T, any, E>
+): Struct<T, null, E> {
   return new Struct({
     type: 'dynamic',
     schema: null,
@@ -108,8 +137,10 @@ export function dynamic<T>(
  * circular definition problem.
  */
 
-export function lazy<T>(fn: () => Struct<T, any>): Struct<T, null> {
-  let struct: Struct<T, any> | undefined
+export function lazy<T, E extends Error>(
+  fn: () => Struct<T, any, E>
+): Struct<T, null, E> {
+  let struct: Struct<T, any, E> | undefined
   return new Struct({
     type: 'lazy',
     schema: null,
@@ -136,9 +167,13 @@ export function lazy<T>(fn: () => Struct<T, any>): Struct<T, null> {
  */
 
 export function omit<S extends ObjectSchema, K extends keyof S>(
-  struct: Struct<ObjectType<S>, S>,
+  struct: Struct<ObjectType<S>, S, any>,
   keys: K[]
-): Struct<ObjectType<Omit<S, K>>, Omit<S, K>> {
+): Struct<
+  ObjectType<Omit<S, K>>,
+  Omit<S, K>,
+  ObjectError<S> | TypeErrorDetail
+> {
   const { schema } = struct
   const subschema: any = { ...schema }
 
@@ -179,7 +214,11 @@ export function partial<S extends ObjectSchema>(
 export function pick<S extends ObjectSchema, K extends keyof S>(
   struct: Struct<ObjectType<S>, S>,
   keys: K[]
-): Struct<ObjectType<Pick<S, K>>, Pick<S, K>> {
+): Struct<
+  ObjectType<Pick<S, K>>,
+  Pick<S, K>,
+  ObjectError<S> | TypeErrorDetail
+> {
   const { schema } = struct
   const subschema: any = {}
 

--- a/src/structs/utilities.ts
+++ b/src/structs/utilities.ts
@@ -63,7 +63,10 @@ export function assign(...Structs: Struct<any>[]): any {
  * Define a new struct type with a custom validation function.
  */
 
-export function define<T, E extends Error>(name: string, validator: Validator<E>): Struct<T, null, E> {
+export function define<T, E extends Error>(
+  name: string,
+  validator: Validator<E>
+): Struct<T, null, E> {
   return new Struct({ type: name, schema: null, validator })
 }
 
@@ -193,7 +196,10 @@ export function pick<S extends ObjectSchema, K extends keyof S>(
  * @deprecated This function has been renamed to `define`.
  */
 
-export function struct<T, E extends Error>(name: string, validator: Validator<E>): Struct<T, null, E> {
+export function struct<T, E extends Error>(
+  name: string,
+  validator: Validator<E>
+): Struct<T, null, E> {
   console.warn(
     'superstruct@0.11 - The `struct` helper has been renamed to `define`.'
   )

--- a/src/structs/utilities.ts
+++ b/src/structs/utilities.ts
@@ -1,6 +1,7 @@
 import { Struct, Context, Validator } from '../struct'
 import { object, optional } from './types'
 import { ObjectSchema, Assign, ObjectType, PartialObjectSchema } from '../utils'
+import { Error } from '../error'
 
 /**
  * Create a new struct that combines the properties properties from multiple
@@ -62,7 +63,7 @@ export function assign(...Structs: Struct<any>[]): any {
  * Define a new struct type with a custom validation function.
  */
 
-export function define<T>(name: string, validator: Validator): Struct<T, null> {
+export function define<T, E extends Error>(name: string, validator: Validator<E>): Struct<T, null, E> {
   return new Struct({ type: name, schema: null, validator })
 }
 
@@ -192,7 +193,7 @@ export function pick<S extends ObjectSchema, K extends keyof S>(
  * @deprecated This function has been renamed to `define`.
  */
 
-export function struct<T>(name: string, validator: Validator): Struct<T, null> {
+export function struct<T, E extends Error>(name: string, validator: Validator<E>): Struct<T, null, E> {
   console.warn(
     'superstruct@0.11 - The `struct` helper has been renamed to `define`.'
   )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,6 @@ export function toFailure<T, S, E extends ErrorDetail>(
     branch,
     message,
     detail: result,
-    failures: [],
   }
 }
 
@@ -339,7 +338,7 @@ export type StructSchema<T> = [T] extends [string]
   : T extends Array<infer E>
   ? T extends IsTuple<T>
     ? null
-    : Struct<E>
+    : Struct<E, unknown, ErrorDetail>
   : T extends Promise<any>
   ? null
   : T extends object

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,6 +154,7 @@ export function* run<T, S, E extends Error>(
       ),
       undefined,
     ]
+    return
   }
 
   for (const failure of failures) {

--- a/test/api/throw.ts
+++ b/test/api/throw.ts
@@ -1,0 +1,29 @@
+import { deepStrictEqual, strictEqual } from 'assert'
+import { StructError, define } from '../..'
+
+describe('throw errors', () => {
+  it('throw error in define', () => {
+    const S = define<string>('email', () => {
+      throw Error('validation error')
+    })
+    const [err, value] = S.validate(null)
+    strictEqual(value, undefined)
+    strictEqual(err instanceof StructError, true)
+    deepStrictEqual(Array.from(err!.failures()), [
+      {
+        value: null,
+        key: undefined,
+        type: 'email',
+        refinement: undefined,
+        message: 'Throw error in run validation: `Error: validation error`',
+        path: [],
+        branch: [null],
+        detail: {
+          class: 'throw',
+          error: new Error('validation error'),
+          message: 'Throw error in run validation: `Error: validation error`',
+        },
+      },
+    ])
+  })
+})

--- a/test/api/validate.ts
+++ b/test/api/validate.ts
@@ -26,6 +26,12 @@ describe('validate', () => {
         message: 'Expected a string, but received: 42',
         path: [],
         branch: [42],
+        detail: {
+          actually: 42,
+          class: 'type',
+          except: 'string',
+          message: 'Expected a string, but received: 42',
+        },
       },
     ])
   })
@@ -44,6 +50,12 @@ describe('validate', () => {
         message: 'Expected a string, but received: 42',
         path: [],
         branch: [42],
+        detail: {
+          actually: 42,
+          class: 'type',
+          except: 'string',
+          message: 'Expected a string, but received: 42',
+        },
       },
     ])
   })

--- a/test/api/validate.ts
+++ b/test/api/validate.ts
@@ -17,7 +17,7 @@ describe('validate', () => {
     const [err, value] = validate(42, S)
     strictEqual(value, undefined)
     strictEqual(err instanceof StructError, true)
-    deepStrictEqual(Array.from((err as StructError).failures()), [
+    deepStrictEqual(Array.from(err!.failures()), [
       {
         value: 42,
         key: undefined,
@@ -35,7 +35,7 @@ describe('validate', () => {
     const [err, value] = S.validate(42)
     strictEqual(value, undefined)
     strictEqual(err instanceof StructError, true)
-    deepStrictEqual(Array.from((err as StructError).failures()), [
+    deepStrictEqual(Array.from(err!.failures()), [
       {
         value: 42,
         key: undefined,
@@ -52,14 +52,14 @@ describe('validate', () => {
     const S = object({ author: object({ name: string() }) })
     const [err] = S.validate({ author: { name: 42 } })
     strictEqual(
-      (err as StructError).message,
+      err!.message,
       'At path: author.name -- Expected a string, but received: 42'
     )
   })
 
   it('early exit', () => {
     let ranA = false
-    let ranB = false
+    const ranB = false
 
     const A = define('A', (x) => {
       ranA = true

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,6 +11,7 @@ describe('superstruct', () => {
     require('./api/is')
     require('./api/mask')
     require('./api/validate')
+    require('./api/throw')
   })
 
   describe('validation', () => {

--- a/test/validation/throw/invalid.ts
+++ b/test/validation/throw/invalid.ts
@@ -1,0 +1,17 @@
+import { define } from '../../..'
+
+export const Struct = define<string>('email', () => {
+  throw Error('validation error')
+})
+
+export const data = 'invalid'
+
+export const failures = [
+  {
+    value: 'invalid',
+    type: 'email',
+    refinement: undefined,
+    path: [],
+    branch: [data],
+  },
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,14 +1173,6 @@
     "@typescript-eslint/typescript-estree" "4.13.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.12.0.tgz#beeb8beca895a07b10c593185a5612f1085ef279"
-  integrity sha512-QVf9oCSVLte/8jvOsxmgBdOaoe2J0wtEmBr13Yz0rkBNkl5D8bfnf6G4Vhox9qqMIoG7QQoVwd2eG9DM/ge4Qg==
-  dependencies:
-    "@typescript-eslint/types" "4.12.0"
-    "@typescript-eslint/visitor-keys" "4.12.0"
-
 "@typescript-eslint/scope-manager@4.13.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz#5b45912a9aa26b29603d8fa28f5e09088b947141"
@@ -1189,29 +1181,10 @@
     "@typescript-eslint/types" "4.13.0"
     "@typescript-eslint/visitor-keys" "4.13.0"
 
-"@typescript-eslint/types@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.12.0.tgz#fb891fe7ccc9ea8b2bbd2780e36da45d0dc055e5"
-  integrity sha512-N2RhGeheVLGtyy+CxRmxdsniB7sMSCfsnbh8K/+RUIXYYq3Ub5+sukRCjVE80QerrUBvuEvs4fDhz5AW/pcL6g==
-
 "@typescript-eslint/types@4.13.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.13.0.tgz#6a7c6015a59a08fbd70daa8c83dfff86250502f8"
   integrity sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
-
-"@typescript-eslint/typescript-estree@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.12.0.tgz#3963418c850f564bdab3882ae23795d115d6d32e"
-  integrity sha512-gZkFcmmp/CnzqD2RKMich2/FjBTsYopjiwJCroxqHZIY11IIoN0l5lKqcgoAPKHt33H2mAkSfvzj8i44Jm7F4w==
-  dependencies:
-    "@typescript-eslint/types" "4.12.0"
-    "@typescript-eslint/visitor-keys" "4.12.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.13.0":
   version "4.13.0"
@@ -1226,14 +1199,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.12.0.tgz#a470a79be6958075fa91c725371a83baf428a67a"
-  integrity sha512-hVpsLARbDh4B9TKYz5cLbcdMIOAoBYgFPCSP9FFS/liSF+b33gVNq8JHY3QGhHNVz85hObvL7BEYLlgx553WCw==
-  dependencies:
-    "@typescript-eslint/types" "4.12.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.13.0":
   version "4.13.0"


### PR DESCRIPTION
ref #568

A design proposal for structurally expressing errors. This PR makes it possible to support custom error messages and i18n. This library will be available for displaying errors to users.

For example, `size(string(), 1, 100)` outputs the error message` ${expected} with a length ${of} but received one with a length of ' ${length}'`. This change outputs the following error content in addition to the message. It is possible to format the error message according to the context and language.

```ts
interface SizeErrorDetail<T extends number | Date> extends ErrorDetail {
  class: 'size'
  actually: T
  min: T | undefined
  max: T | undefined
  minExlusive: boolean
  maxExlusive: boolean
}
```

- todos
  - resolve conflicts
  - think about compatibility