### PR TITLE
fix: fixed describe for some literal types

### DIFF
--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -233,16 +233,31 @@ export function intersection(Structs: Array<Struct<any, any>>): any {
  */
 
 export function literal<T extends boolean>(constant: T): Struct<T, null>
-export function literal<T extends number>(constant: T): Struct<T, null>
-export function literal<T extends string>(constant: T): Struct<T, null>
-export function literal<T>(constant: T): Struct<T, null>
+export function literal<T extends number>(
+  constant: T
+): Struct<T, { [K in T[][number]]: K }>
+export function literal<T extends string>(
+  constant: T
+): Struct<T, { [K in T[][number]]: K }>
+export function literal<T>(
+  constant: T
+): Struct<T, T extends string | number ? { [K in T[][number]]: K } : null>
 export function literal<T>(constant: T): any {
   const description = print(constant)
-  return define('literal', (value) => {
-    return (
-      value === constant ||
-      `Expected the literal \`${description}\`, but received: ${print(value)}`
-    )
+  return new Struct({
+    type: 'literal',
+    schema:
+      typeof constant === 'string' || typeof constant === 'number'
+        ? {
+            [description]: constant,
+          }
+        : null,
+    validator(value) {
+      return (
+        value === constant ||
+        `Expected the literal \`${description}\`, but received: ${print(value)}`
+      )
+    },
   })
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,6 +229,12 @@ export type IsGenericString<T> = T extends string
     : never
   : never
 
+export type IsGenericNumber<T> = T extends number
+  ? number extends T
+    ? T
+    : never
+  : never
+
 /**
  * Normalize properties of a type that allow `undefined` to make them optional.
  */
@@ -298,6 +304,10 @@ export type StructSchema<T> = [T] extends [string]
   ? [T] extends [IsGenericString<T>]
     ? null
     : EnumSchema<T>
+  : [T] extends [number]
+  ? [T] extends [IsGenericNumber<T>]
+    ? null
+    : EnumSchema<T>
   : T extends
       | number
       | boolean
@@ -334,7 +344,7 @@ export type StructSchema<T> = [T] extends [string]
  * A schema for enum structs.
  */
 
-export type EnumSchema<T extends string> = { [K in T]: K }
+export type EnumSchema<T extends string | number> = { [K in T]: K }
 
 /**
  * A schema for tuple structs.

--- a/test/typings/describe.ts
+++ b/test/typings/describe.ts
@@ -54,6 +54,10 @@ test<Describe<'a' | 'b' | 'c'>>((x) => {
   return enums(['a', 'b', 'c'])
 })
 
+test<Describe<1 | 2 | 3>>((x) => {
+  return enums([1, 2, 3])
+})
+
 test<Describe<Function>>((x) => {
   return func()
 })
@@ -68,6 +72,10 @@ test<Describe<string & number>>((x) => {
 
 test<Describe<42>>((x) => {
   return literal(42)
+})
+
+test<Describe<'test'>>((x) => {
+  return literal('test')
 })
 
 test<Describe<Map<string, number>>>((x) => {


### PR DESCRIPTION
Small PR to fix some interesting false error cases of using describe with literal types:

```ts
const a: Describe<1 | 2 | 3> = enums([1, 2, 3]) // type error
const b: Describe<'1' | '2' | '3'> = enums(['1', '2', '3']) // works

const c: Describe<'test'> = literal('test') // type error
const d: Describe<1'> = literal(1) // works
```

I've added tests for the failing cases, with the fix being to provide the same schema type as `enum` when using `literal`.