### PR TITLE
improve defaulted coercions types

### DIFF
--- a/src/structs/coercions.ts
+++ b/src/structs/coercions.ts
@@ -37,7 +37,7 @@ export function coerce<T, S, C>(
 
 export function defaulted<T, S>(
   struct: Struct<T, S>,
-  fallback: any,
+  fallback: Struct<T, S>['TYPE'],
   options: {
     strict?: boolean
   } = {}


### PR DESCRIPTION
Is there any special reason we use any here? I think the defaulted value should match the struct shape. with this simple change, we could get autocomplete from editor.

![image](https://user-images.githubusercontent.com/33362998/107869524-bea93300-6e54-11eb-8cf5-f55f40975ddb.png)

![image](https://user-images.githubusercontent.com/33362998/107869531-cd8fe580-6e54-11eb-9c1e-6155f295ff78.png)
