### PR TITLE
Allow optional enums

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,7 +203,9 @@ export type Assign<T, U> = Simplify<U & Omit<T, keyof U>>
  * A schema for enum structs.
  */
 
-export type EnumSchema<T extends string | number> = { [K in T]: K }
+export type EnumSchema<T extends string | number | undefined> = {
+  [K in NonNullable<T>]: K
+}
 
 /**
  * Check if a type is an exact match.
@@ -307,14 +309,14 @@ export type If<B extends Boolean, Then, Else> = B extends true ? Then : Else
  * A schema for any type of struct.
  */
 
-export type StructSchema<T> = [T] extends [string]
-  ? [T] extends [IsMatch<T, string>]
+export type StructSchema<T> = [T] extends [string | undefined]
+  ? [T] extends [IsMatch<T, string | undefined>]
     ? null
     : [T] extends [IsUnion<T>]
     ? EnumSchema<T>
     : T
-  : [T] extends [number]
-  ? [T] extends [IsMatch<T, number>]
+  : [T] extends [number | undefined]
+  ? [T] extends [IsMatch<T, number | undefined>]
     ? null
     : [T] extends [IsUnion<T>]
     ? EnumSchema<T>


### PR DESCRIPTION
Fix for #693 

To be honest, simply adding undefined feels kind of wrong in this case. But it was the only solution I came up with and as far as my few tests sufficed, it yields correct types and `npm run test` doesn't complain either.