### PR TITLE
feat(union): add support for coercion of union types

### DIFF
--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -625,6 +625,14 @@ export function union(Structs: Struct<any>[]): any {
   return new Struct({
     type: 'union',
     schema: null,
+    coercer(value, ctx) {
+      const firstMatch =
+        Structs.find((s) => {
+          const [e] = s.validate(value, { coerce: true })
+          return !e
+        }) || unknown()
+      return firstMatch.coercer(value, ctx)
+    },
     validator(value, ctx) {
       const failures = []
 

--- a/test/validation/union/coercion-nested.ts
+++ b/test/validation/union/coercion-nested.ts
@@ -1,0 +1,12 @@
+import { union, string, number, defaulted, type } from '../../..'
+
+const A = string()
+const B = type({ a: number(), b: defaulted(number(), 5) })
+
+export const Struct = union([A, B])
+
+export const data = { a: 5 }
+
+export const output = { a: 5, b: 5 }
+
+export const create = true

--- a/test/validation/union/coercion.ts
+++ b/test/validation/union/coercion.ts
@@ -1,0 +1,12 @@
+import { union, string, number, defaulted } from '../../..'
+
+const A = defaulted(string(), 'foo')
+const B = number()
+
+export const Struct = union([A, B])
+
+export const data = undefined
+
+export const output = 'foo'
+
+export const create = true


### PR DESCRIPTION
Previously union types were not coerced due to the ambiguous behavior that might result. There may
be multiple Structs in a union that could coerce a given value (for example, defaulted(string()) and
defaulted(number()) would both successfully coerce an undefined value). This change takes an opinion
that the first Struct passed that can be coerced into a valid object from the passed value shall
take precedence, allowing coercion to occur in some form, even if its opinionated

resolves #580

---

I've left out docs until this approach is approved overall. The tests illustrate what happens, but basically it optimistically assumes the first valid coercing struct that is passed into the union is the right one to use *for coercion* A _coercable_ value does not pass validation after this change--this only affects the behavior of coercion.

So for example

```
const MyUnion = union(string(), defaulted(number(), 5))

const myUnion = create(undefined, MyUnion); // myUnion === 5
assert(undefined, MyUnion) // throws
const [ e, v ] = validate(undefined, MyUnion) // [error, undefined]
const [ e, v ] = validate(undefined, MyUnion, { coerce: true }) // [undefined, 5]
```

