### PR TITLE
feat(partial): add support for returning type from partial if passed a type

### DIFF
--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -92,7 +92,7 @@ partial(
 { name: 'Jane' }
 ```
 
-`partial` allows you to create a new struct based on an existing object struct, but with all of its properties being optional.
+`partial` allows you to create a new struct based on an existing object or type struct, but with all of its properties being optional.
 
 ### `pick`
 

--- a/src/structs/utilities.ts
+++ b/src/structs/utilities.ts
@@ -170,7 +170,7 @@ export function omit<S extends ObjectSchema, K extends keyof S>(
 }
 
 /**
- * Create a new struct based on an existing object struct, but with all of its
+ * Create a new struct based on an existing object or type struct, but with all of its
  * properties allowed to be `undefined`.
  *
  * Like TypeScript's `Partial` utility.
@@ -186,7 +186,7 @@ export function partial<S extends ObjectSchema>(
     schema[key] = optional(schema[key])
   }
 
-  return object(schema) as any
+  return (struct.type === 'type' ? type : object)(schema) as any
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -277,7 +277,7 @@ export type Optionalize<S extends object> = OmitBy<S, undefined> &
   Partial<PickBy<S, undefined>>
 
 /**
- * Transform an object schema type to represent a partial.
+ * Transform an object or type schema type to represent a partial.
  */
 
 export type PartialObjectSchema<S extends ObjectSchema> = {

--- a/test/validation/partial/composed-type.ts
+++ b/test/validation/partial/composed-type.ts
@@ -1,0 +1,18 @@
+import { partial, type, string, number } from '../../..'
+
+export const Struct = partial(
+  type({
+    name: string(),
+    age: number(),
+  })
+)
+
+export const data = {
+  name: 'john',
+  location: 'mars',
+}
+
+export const output = {
+  name: 'john',
+  location: 'mars',
+}


### PR DESCRIPTION
I have a union of types, and i want to add validation to it so that if it contains any properties, they must represent the entire type that property matches with.

```
const A = type({ a: number(), b: number() });
const B = type({ c: number(), d: number() });

const SuperInterface = refine(union([ A. B ]), 'no partial types', val => {
  if (!is(val, A) && is(val, partial(A))) return false;
  // in the test below, `is(val, partial(b))` fails because of the A properties and
  // how partial returns a restrictive object() where extra props disqualify val
  if (!is(val, B) && is(val, partial(B))) return false;
  return true;
}

it('should throw if a partial interface is passed in addition to a full one', () => {
  // It is a SuperInterface because it matches {a,b}, however
  // it should not pass validation because {c,d} lacks {d}
  expect(() => assert({a:1, b:2, c:4}, SuperInterface)).toThrow()
  
  // Since the is(val, partial(B)) validation checks all properties of val and
  // sees more than expected, even though it is a partial of the _type interface_ it thinks
  // its something else entirely and doesn't match
})
```

There are other ways to do this, but it seemed idiomatic to do it this way and was surprised that it wasn't supported (plus it was simple to add)

Worth thinking about if there is/are cases this doesn't make sense.