### PR TITLE
feat: not empty refinement

### DIFF
--- a/docs/reference/refinements.md
+++ b/docs/reference/refinements.md
@@ -46,6 +46,15 @@ max(number(), 0)
 
 > 🤖 If you need an exclusive maxmimum you can pass `{ exclusive: true }` as the third argument, like `max(number(), 0, { exclusive: true })` for positive numbers.
 
+### `notEmpty`
+
+```
+notEmpty(string())
+notEmpty(array())
+```
+
+`notEmpty` enforces that a string, array, map, or set is not empty. As you may imagine, it does the exact opposite of `empty`.
+
 ### `pattern`
 
 ```ts

--- a/src/structs/refinements.ts
+++ b/src/structs/refinements.ts
@@ -4,27 +4,41 @@ import { toFailures } from '../utils'
 /**
  * Ensure that a string, array, map, or set is empty.
  */
-
 export function empty<
   T extends string | any[] | Map<any, any> | Set<any>,
   S extends any
 >(struct: Struct<T, S>): Struct<T, S> {
-  const expected = `Expected an empty ${struct.type}`
-
   return refine(struct, 'empty', (value) => {
-    if (value instanceof Map || value instanceof Set) {
-      const { size } = value
-      return (
-        size === 0 || `${expected} but received one with a size of \`${size}\``
-      )
-    } else {
-      const { length } = value as string | any[]
-      return (
-        length === 0 ||
-        `${expected} but received one with a length of \`${length}\``
-      )
-    }
+    const size = getSize(value)
+    return (
+      size === 0 ||
+      `Expected an empty ${struct.type} but received one with a size of \`${size}\``
+    )
   })
+}
+
+/**
+ * Ensure that a string, array, map or set is not empty.
+ */
+export function notEmpty<
+  T extends string | any[] | Map<any, any> | Set<any>,
+  S extends any
+>(struct: Struct<T, S>): Struct<T, S> {
+  return refine(struct, 'not empty', (value) => {
+    const size = getSize(value)
+    return (
+      size > 0 ||
+      `Expected a not empty ${struct.type} but received an empty one`
+    )
+  })
+}
+
+function getSize(value: string | any[] | Map<any, any> | Set<any>): number {
+  if (value instanceof Map || value instanceof Set) {
+    return value.size
+  } else {
+    return value.length
+  }
 }
 
 /**

--- a/test/typings/not-empty.ts
+++ b/test/typings/not-empty.ts
@@ -1,0 +1,22 @@
+import { assert, notEmpty, string, array, map, set } from '../..'
+import { test } from '..'
+
+test<string>((x) => {
+  assert(x, notEmpty(string()))
+  return x
+})
+
+test<Array<unknown>>((x) => {
+  assert(x, notEmpty(array()))
+  return x
+})
+
+test<Set<unknown>>((x) => {
+  assert(x, notEmpty(set()))
+  return x
+})
+
+test<Map<unknown, unknown>>((x) => {
+  assert(x, notEmpty(map()))
+  return x
+})


### PR DESCRIPTION
I believe it makes sense to have this refinement. Most of the times you want to ensure that an array/string/set/map is _not_ empty rather than empty. 