### PR TITLE
Add `nonempty` refinement

### DIFF
--- a/docs/reference/refinements.md
+++ b/docs/reference/refinements.md
@@ -46,6 +46,15 @@ max(number(), 0)
 
 > 🤖 If you need an exclusive maxmimum you can pass `{ exclusive: true }` as the third argument, like `max(number(), 0, { exclusive: true })` for negative numbers.
 
+### `notEmpty`
+
+```
+notEmpty(string())
+notEmpty(array())
+```
+
+`notEmpty` enforces that a string, array, map, or set is not empty. As you may imagine, it does the exact opposite of `empty`.
+
 ### `pattern`
 
 ```ts

--- a/docs/reference/refinements.md
+++ b/docs/reference/refinements.md
@@ -18,20 +18,6 @@ empty(array())
 
 > 🤖 Technically this is the same as using [`size`](#size) of zero, but "empty" feels slightly nicer and will give a slightly easier to read error.
 
-### `min`
-
-```ts
-min(number(), 9000)
-```
-
-```ts
-9001
-```
-
-`min` enforces that a `number` struct is greater than a threshold.
-
-> 🤖 If you need an exclusive minimum you can pass `{ exclusive: true }` as the third argument, like `min(number(), 0, { exclusive: true })` for positive numbers.
-
 ### `max`
 
 ```ts
@@ -46,14 +32,28 @@ max(number(), 0)
 
 > 🤖 If you need an exclusive maxmimum you can pass `{ exclusive: true }` as the third argument, like `max(number(), 0, { exclusive: true })` for negative numbers.
 
-### `notEmpty`
+### `min`
 
-```
-notEmpty(string())
-notEmpty(array())
+```ts
+min(number(), 9000)
 ```
 
-`notEmpty` enforces that a string, array, map, or set is not empty. As you may imagine, it does the exact opposite of `empty`.
+```ts
+9001
+```
+
+`min` enforces that a `number` struct is greater than a threshold.
+
+> 🤖 If you need an exclusive minimum you can pass `{ exclusive: true }` as the third argument, like `min(number(), 0, { exclusive: true })` for positive numbers.
+
+### `nonempty`
+
+```ts
+nonempty(string())
+nonempty(array())
+```
+
+`nonempty` enforces that a string, array, map, or set is not empty. This does the opposite of `empty`.
 
 ### `pattern`
 

--- a/src/structs/refinements.ts
+++ b/src/structs/refinements.ts
@@ -4,6 +4,7 @@ import { toFailures } from '../utils'
 /**
  * Ensure that a string, array, map, or set is empty.
  */
+
 export function empty<
   T extends string | any[] | Map<any, any> | Set<any>,
   S extends any
@@ -13,22 +14,6 @@ export function empty<
     return (
       size === 0 ||
       `Expected an empty ${struct.type} but received one with a size of \`${size}\``
-    )
-  })
-}
-
-/**
- * Ensure that a string, array, map or set is not empty.
- */
-export function notEmpty<
-  T extends string | any[] | Map<any, any> | Set<any>,
-  S extends any
->(struct: Struct<T, S>): Struct<T, S> {
-  return refine(struct, 'not empty', (value) => {
-    const size = getSize(value)
-    return (
-      size > 0 ||
-      `Expected a not empty ${struct.type} but received an empty one`
     )
   })
 }
@@ -84,6 +69,23 @@ export function min<T extends number | Date, S extends any>(
           }${threshold} but received \`${value}\``
   })
 }
+
+/**
+ * Ensure that a string, array, map or set is not empty.
+ */
+
+export function nonempty<
+  T extends string | any[] | Map<any, any> | Set<any>,
+  S extends any
+>(struct: Struct<T, S>): Struct<T, S> {
+  return refine(struct, 'nonempty', (value) => {
+    const size = getSize(value)
+    return (
+      size > 0 || `Expected a nonempty ${struct.type} but received an empty one`
+    )
+  })
+}
+
 /**
  * Ensure that a string matches a regular expression.
  */

--- a/src/structs/refinements.ts
+++ b/src/structs/refinements.ts
@@ -4,27 +4,41 @@ import { toFailures } from '../utils'
 /**
  * Ensure that a string, array, map, or set is empty.
  */
-
 export function empty<
   T extends string | any[] | Map<any, any> | Set<any>,
   S extends any
 >(struct: Struct<T, S>): Struct<T, S> {
-  const expected = `Expected an empty ${struct.type}`
-
   return refine(struct, 'empty', (value) => {
-    if (value instanceof Map || value instanceof Set) {
-      const { size } = value
-      return (
-        size === 0 || `${expected} but received one with a size of \`${size}\``
-      )
-    } else {
-      const { length } = value as string | any[]
-      return (
-        length === 0 ||
-        `${expected} but received one with a length of \`${length}\``
-      )
-    }
+    const size = getSize(value)
+    return (
+      size === 0 ||
+      `Expected an empty ${struct.type} but received one with a size of \`${size}\``
+    )
   })
+}
+
+/**
+ * Ensure that a string, array, map or set is not empty.
+ */
+export function notEmpty<
+  T extends string | any[] | Map<any, any> | Set<any>,
+  S extends any
+>(struct: Struct<T, S>): Struct<T, S> {
+  return refine(struct, 'not empty', (value) => {
+    const size = getSize(value)
+    return (
+      size > 0 ||
+      `Expected a not empty ${struct.type} but received an empty one`
+    )
+  })
+}
+
+function getSize(value: string | any[] | Map<any, any> | Set<any>): number {
+  if (value instanceof Map || value instanceof Set) {
+    return value.size
+  } else {
+    return value.length
+  }
 }
 
 /**

--- a/test/typings/nonempty.ts
+++ b/test/typings/nonempty.ts
@@ -1,22 +1,22 @@
-import { assert, notEmpty, string, array, map, set } from '../..'
+import { assert, nonempty, string, array, map, set } from '../../lib'
 import { test } from '..'
 
 test<string>((x) => {
-  assert(x, notEmpty(string()))
+  assert(x, nonempty(string()))
   return x
 })
 
 test<Array<unknown>>((x) => {
-  assert(x, notEmpty(array()))
+  assert(x, nonempty(array()))
   return x
 })
 
 test<Set<unknown>>((x) => {
-  assert(x, notEmpty(set()))
+  assert(x, nonempty(set()))
   return x
 })
 
 test<Map<unknown, unknown>>((x) => {
-  assert(x, notEmpty(map()))
+  assert(x, nonempty(map()))
   return x
 })

--- a/test/typings/not-empty.ts
+++ b/test/typings/not-empty.ts
@@ -1,0 +1,22 @@
+import { assert, notEmpty, string, array, map, set } from '../..'
+import { test } from '..'
+
+test<string>((x) => {
+  assert(x, notEmpty(string()))
+  return x
+})
+
+test<Array<unknown>>((x) => {
+  assert(x, notEmpty(array()))
+  return x
+})
+
+test<Set<unknown>>((x) => {
+  assert(x, notEmpty(set()))
+  return x
+})
+
+test<Map<unknown, unknown>>((x) => {
+  assert(x, notEmpty(map()))
+  return x
+})


### PR DESCRIPTION
This resolves the issues raised in #755 which hasn't been updated in several months.