### PR TITLE
Respect refiner in `dynamic` and `lazy`

### DIFF
--- a/src/structs/utilities.ts
+++ b/src/structs/utilities.ts
@@ -149,6 +149,10 @@ export function lazy<T>(fn: () => Struct<T, any>): Struct<T, null> {
       struct ??= fn()
       return struct.coercer(value, ctx)
     },
+    refiner(value, ctx) {
+      struct ??= fn()
+      return struct.refiner(value, ctx)
+    },
   })
 }
 

--- a/src/structs/utilities.ts
+++ b/src/structs/utilities.ts
@@ -116,6 +116,10 @@ export function dynamic<T>(
       const struct = fn(value, ctx)
       return struct.coercer(value, ctx)
     },
+    refiner(value, ctx) {
+      const struct = fn(value, ctx)
+      return struct.refiner(value, ctx)
+    },
   })
 }
 

--- a/test/validation/dynamic/with-refiners.ts
+++ b/test/validation/dynamic/with-refiners.ts
@@ -1,0 +1,15 @@
+import { dynamic, string, nonempty } from '../../..'
+
+export const Struct = dynamic(() => nonempty(string()))
+
+export const data = ''
+
+export const failures = [
+  {
+    value: data,
+    type: 'string',
+    refinement: 'nonempty',
+    path: [],
+    branch: [data],
+  },
+]

--- a/test/validation/lazy/with-refiners.ts
+++ b/test/validation/lazy/with-refiners.ts
@@ -1,0 +1,15 @@
+import { lazy, nonempty, string } from '../../..'
+
+export const Struct = lazy(() => nonempty(string()))
+
+export const data = ''
+
+export const failures = [
+  {
+    value: data,
+    type: 'string',
+    refinement: 'nonempty',
+    path: [],
+    branch: [data],
+  },
+]


### PR DESCRIPTION
This PR fixes the refiners being previously ignored in the structs returned by `lazy` and `dynamic` utilities.

I have added 2 new test cases that prove the refiners work now.

Fixes #830 