### PR TITLE
Change `struct()` to `object()` in `object` docs

### DIFF
--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -214,7 +214,7 @@ null
 ### `object`
 
 ```ts
-struct({
+object({
   id: number(),
   name: string(),
 })


### PR DESCRIPTION
This PR fixes an issue with the example code for `object`. It should use the `object` function instead of the `struct` function.