### PR TITLE
Use type for omit output if that's the struct's input

### DIFF
--- a/src/structs/utilities.ts
+++ b/src/structs/utilities.ts
@@ -166,7 +166,10 @@ export function omit<S extends ObjectSchema, K extends keyof S>(
     delete subschema[key]
   }
 
-  return object(subschema as Omit<S, K>)
+  switch (struct.type) {
+    case "type": return type(subschema as Omit<S, K>)
+    default: return object(subschema as Omit<S, K>)
+  }
 }
 
 /**

--- a/test/typings/omit.ts
+++ b/test/typings/omit.ts
@@ -1,9 +1,16 @@
-import { assert, omit, object, number, string } from '../..'
+import { assert, omit, object, number, string, type } from '../..'
 import { test } from '..'
 
 test<{
   b: string
 }>((x) => {
   assert(x, omit(object({ a: number(), b: string() }), ['a']))
+  return x
+})
+
+test<{
+  b: string
+}>((x) => {
+  assert(x, omit(type({ a: number(), b: string() }), ['a']))
   return x
 })

--- a/test/validation/omit/valid-type.ts
+++ b/test/validation/omit/valid-type.ts
@@ -1,0 +1,19 @@
+import { omit, type, string, number } from '../../../lib'
+
+export const Struct = omit(
+  type({
+    name: string(),
+    age: number(),
+  }),
+  ['age']
+)
+
+export const data = {
+  name: 'john',
+  unknownProperty: 'unknown',
+}
+
+export const output = {
+  name: 'john',
+  unknownProperty: 'unknown',
+}


### PR DESCRIPTION
This change basically allows a `type` struct as input to `omit` to be preserved. It's not very useful for actual checking since `type` accepts anything (even the "omitted" key) but it does remove the key from the returned type and preserves the intuitive behavior behind `type`.

I believe this relates to https://github.com/ianstormtaylor/superstruct/issues/829 but it's missing implementations for `pick` and `partial`.