### PR TITLE
Fixes #971 - nested coercion

### DIFF
--- a/src/struct.ts
+++ b/src/struct.ts
@@ -12,7 +12,10 @@ export class Struct<T = unknown, S = unknown> {
   type: string
   schema: S
   coercer: (value: unknown, context: Context) => unknown
-  validator: (value: unknown, context: Context) => Iterable<Failure>
+  validator: (
+    value: unknown,
+    context: Context & { coerce: boolean; mask: boolean }
+  ) => Iterable<Failure>
   refiner: (value: T, context: Context) => Iterable<Failure>
   entries: (
     value: unknown,

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -501,9 +501,7 @@ export function union<A extends AnyStruct, B extends AnyStruct[]>(
     schema: null,
     *entries(value, ctx) {
       const S = getMatchingStruct(value)
-      const entiresToYield = [...S.entries(value, ctx)]
-
-      yield* entiresToYield
+      yield* S.entries(value, ctx)
     },
     coercer(value, ctx) {
       const firstMatch = getMatchingStruct(value)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,7 +148,12 @@ export function* run<T, S>(
 
   let valid = true
 
-  for (const failure of struct.validator(value, ctx)) {
+  for (const failure of struct.validator(value, {
+    path,
+    branch,
+    coerce,
+    mask,
+  })) {
     valid = false
     yield [failure, undefined]
   }

--- a/test/api/coerce.ts
+++ b/test/api/coerce.ts
@@ -1,0 +1,60 @@
+import { deepStrictEqual } from 'assert'
+import { string, object, union, coerce, date, type, validate } from '../..'
+
+const CoercedDate = coerce(date(), string(), (dateString) => {
+  return new Date(dateString)
+})
+
+const testDateString = '2021-11-11T11:11:11.111Z'
+const expectedDateObject = new Date(testDateString)
+
+describe('coercion', () => {
+  it('works on its own', () => {
+    const simpleValidationWithoutObject = union([CoercedDate])
+
+    const [, coercedDate] = validate(
+      '2021-11-11T11:11:11.111Z',
+      simpleValidationWithoutObject,
+      {
+        coerce: true,
+      }
+    )
+    deepStrictEqual(coercedDate, expectedDateObject)
+  })
+
+  it('integrates with type() as expected', () => {
+    const simpleValidationWithType = union([
+      type({
+        createdAt: CoercedDate,
+      }),
+    ])
+
+    const [, coercedType] = validate(
+      { createdAt: '2021-11-11T11:11:11.111Z' },
+      simpleValidationWithType,
+      { coerce: true }
+    )
+
+    deepStrictEqual(coercedType, {
+      createdAt: expectedDateObject,
+    })
+  })
+
+  it('integrates with object() as expected', () => {
+    const simpleValidationWithObject = union([
+      object({
+        createdAt: CoercedDate,
+      }),
+    ])
+
+    const [, coercedDateObject] = validate(
+      { createdAt: '2021-11-11T11:11:11.111Z' },
+      simpleValidationWithObject,
+      { coerce: true }
+    )
+
+    deepStrictEqual(coercedDateObject, {
+      createdAt: expectedDateObject,
+    })
+  })
+})

--- a/test/api/coerce.ts
+++ b/test/api/coerce.ts
@@ -47,11 +47,13 @@ describe('coercion', () => {
       }),
     ])
 
-    const [, coercedDateObject] = validate(
+    const [error, coercedDateObject] = validate(
       { createdAt: '2021-11-11T11:11:11.111Z' },
       simpleValidationWithObject,
       { coerce: true }
     )
+
+    deepStrictEqual(error, undefined)
 
     deepStrictEqual(coercedDateObject, {
       createdAt: expectedDateObject,

--- a/test/index.ts
+++ b/test/index.ts
@@ -15,6 +15,7 @@ import {
 describe('superstruct', () => {
   describe('api', () => {
     require('./api/assert')
+    require('./api/coerce')
     require('./api/create')
     require('./api/is')
     require('./api/mask')


### PR DESCRIPTION
Started with a failing test per @yss14's example in the ticket

Tried implementing an entries generator per @ianstormtaylor's suggestion but it didn't seem to do the trick.

Seems @poyangliu was correct: the issue is that the `coerce` bit of context wasn't being propagated in the call to `validate()` in the `run()` method. Added it to the argument to `validate` though I'm not sure this is the correct approach. Perhaps `coerce` and `mask` should be optional members of `Context` in general?

Closes #971 