### PR TITLE
Run refiners as long as validators passed

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,10 +146,10 @@ export function* run<T, S>(
     }
   }
 
-  let validity: StructValidity = 'valid'
+  let status: 'valid' | 'not_refined' | 'not_valid' = 'valid'
 
   for (const failure of struct.validator(value, ctx)) {
-    validity = updateStructValidityAfterFailure(validity, failure)
+    status = 'not_valid'
     yield [failure, undefined]
   }
 
@@ -163,7 +163,7 @@ export function* run<T, S>(
 
     for (const t of ts) {
       if (t[0]) {
-        validity = updateStructValidityAfterFailure(validity, t[0])
+        status = t[0].refinement != null ? 'not_refined' : 'not_valid'
         yield [t[0], undefined]
       } else if (coerce) {
         v = t[1]
@@ -181,33 +181,16 @@ export function* run<T, S>(
     }
   }
 
-  if (validity === 'valid' || validity === 'refinement-failed') {
+  if (status !== 'not_valid') {
     for (const failure of struct.refiner(value as T, ctx)) {
-      validity = updateStructValidityAfterFailure(validity, failure)
+      status = 'not_refined'
       yield [failure, undefined]
     }
   }
 
-  if (validity === 'valid') {
+  if (status === 'valid') {
     yield [undefined, value as T]
   }
-}
-
-type StructValidity = 'valid' | 'invalid' | 'refinement-failed'
-
-function updateStructValidityAfterFailure(
-  validity: StructValidity,
-  failure: Failure
-): StructValidity {
-  if (validity === 'invalid') {
-    return validity
-  }
-
-  if (failure.refinement !== undefined) {
-    return 'refinement-failed'
-  }
-
-  return 'invalid'
 }
 
 /**

--- a/test/validation/refine/invalid-multiple-refinements.ts
+++ b/test/validation/refine/invalid-multiple-refinements.ts
@@ -1,0 +1,41 @@
+import { string, refine, object } from '../../..'
+
+const PasswordValidator = refine(string(), 'MinimumLength', (pw) =>
+  pw.length >= 8 ? true : 'required minimum length of 8'
+)
+const changePasswordStruct = object({
+  newPassword: PasswordValidator,
+  confirmPassword: string(),
+})
+
+export const Struct = refine(
+  changePasswordStruct,
+  'PasswordsDoNotMatch',
+  (values) => {
+    return values.newPassword === values.confirmPassword
+      ? true
+      : 'Passwords do not match'
+  }
+)
+
+export const data = {
+  newPassword: '1234567',
+  confirmPassword: '123456789',
+}
+
+export const failures = [
+  {
+    value: data.newPassword,
+    type: 'string',
+    refinement: 'MinimumLength',
+    path: ['newPassword'],
+    branch: [data, data.newPassword],
+  },
+  {
+    value: data,
+    type: 'object',
+    refinement: 'PasswordsDoNotMatch',
+    path: [],
+    branch: [data],
+  },
+]


### PR DESCRIPTION
Previously refiners ran only when there were no past failures during
validation of the value itself or its subvalues. This behavior was
causing inferior UX when validating forms with additional validations
defined as refiners. If there was a refinement error in some subfield,
the refiners defined on the parent of that subfield were not executed.
Only after fixing the error in the subfield did the user receive
information about the failure on the parent field.

This commit changes the condition under which refinements are run.
Refinements are executed if there were no previous failures or those
failures came exclusively from other refiners.

The change helps in the form validation scenario because as long as the
form structure is valid (which is checked using `validator`s), failures
from all refiners are collected.

Refiners still run only if the general structure of the value is
correct. They will get passed a structurally-valid value. The only
difference now is that those values were may not have been checked via a
refiner.

If some check is so important that other refiners should not
run if that check fails, that check should be defined as a `validator`,
not a `refiner`. Failing that check will not run other refiners.

Fixes https://github.com/ianstormtaylor/superstruct/issues/979