### PR TITLE
Rename CommonJS bundle so as to be compatible with React Native

### DIFF
--- a/config/rollup-cjs.js
+++ b/config/rollup-cjs.js
@@ -1,7 +1,7 @@
 import config from './rollup'
 
 config.output = {
-  file: './lib/index.cjs',
+  file: './lib/index.cjs.js',
   format: 'cjs',
   name: 'Superstruct',
   sourcemap: true,

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "repository": "git://github.com/ianstormtaylor/superstruct.git",
   "source": "./src/index.ts",
   "types": "./lib/index.d.ts",
-  "main": "./lib/index.cjs",
+  "main": "./lib/index.cjs.js",
   "module": "./lib/index.es.js",
   "exports": {
     "import": "./lib/index.es.js",
-    "require": "./lib/index.cjs"
+    "require": "./lib/index.cjs.js"
   },
   "sideEffects": false,
   "files": [

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "@babel/preset-env": "^7.6.3",
     "@babel/preset-typescript": "^7.6.0",
     "@babel/register": "^7.6.2",
+    "@types/expect": "^24.3.0",
     "@types/lodash": "^4.14.144",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.21",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "babel-eslint": "^10.0.3",
+    "cross-env": "^7.0.3",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-import": "^2.22.1",
@@ -52,6 +54,7 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-ts": "^3.0.1",
+    "ts-mocha": "^10.0.0",
     "typescript": "^4.1.2"
   },
   "scripts": {
@@ -69,8 +72,7 @@
     "lint:eslint": "eslint '{src,test}/*.{js,ts}'",
     "lint:prettier": "prettier --list-different '**/*.{js,json,ts}'",
     "release": "yarn build && yarn lint && np",
-    "test": "yarn build:types && yarn test:types && yarn build:cjs && yarn test:mocha",
-    "test:mocha": "mocha --require ./test/register.cjs --require source-map-support/register ./test/index.ts",
+    "test": "cross-env TS_NODE_COMPILER_OPTIONS='{ \"module\": \"commonjs\", \"target\": \"es2019\" }' ts-mocha -p ./test/tsconfig.json ./test/index.ts",
     "test:types": "tsc --noEmit && tsc --project ./test/tsconfig.json --noEmit",
     "watch": "yarn build:cjs --watch",
     "watch:types": "yarn build:types --watch"

--- a/test/api/assert.ts
+++ b/test/api/assert.ts
@@ -1,5 +1,5 @@
 import { throws, doesNotThrow } from 'assert'
-import { assert, string, StructError } from '../..'
+import { assert, string, StructError } from '../../src'
 
 describe('assert', () => {
   it('valid as helper', () => {

--- a/test/api/create.ts
+++ b/test/api/create.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert'
-import { create, string, defaulted } from '../..'
+import { create, string, defaulted } from '../../src'
 
 describe('create', () => {
   it('missing as helper', () => {

--- a/test/api/is.ts
+++ b/test/api/is.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert'
-import { is, string } from '../..'
+import { is, string } from '../../src'
 
 describe('is', () => {
   it('valid as helper', () => {

--- a/test/api/mask.ts
+++ b/test/api/mask.ts
@@ -7,7 +7,7 @@ import {
   StructError,
   array,
   type,
-} from '../..'
+} from '../../src'
 
 describe('mask', () => {
   it('object as helper', () => {

--- a/test/api/validate.ts
+++ b/test/api/validate.ts
@@ -7,7 +7,7 @@ import {
   refine,
   object,
   any,
-} from '../..'
+} from '../../src'
 
 describe('validate', () => {
   it('valid as helper', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -10,7 +10,7 @@ import {
   create as createValue,
   deprecated,
   StructError,
-} from '..'
+} from '../src'
 
 describe('superstruct', () => {
   describe('api', () => {

--- a/test/register.cjs
+++ b/test/register.cjs
@@ -1,3 +1,0 @@
-require('@babel/register')({
-  extensions: ['.js', '.jsx', '.ts', '.tsx'],
-})

--- a/test/typings/any.ts
+++ b/test/typings/any.ts
@@ -1,4 +1,4 @@
-import { assert, any } from '../..'
+import { assert, any } from '../../src'
 import { test } from '..'
 
 test<any>((x) => {

--- a/test/typings/array.ts
+++ b/test/typings/array.ts
@@ -1,4 +1,4 @@
-import { assert, array, number } from '../..'
+import { assert, array, number } from '../../src'
 import { test } from '..'
 
 test<Array<unknown>>((x) => {

--- a/test/typings/assign.ts
+++ b/test/typings/assign.ts
@@ -1,4 +1,4 @@
-import { assert, assign, object, number, string } from '../..'
+import { assert, assign, object, number, string } from '../../src'
 import { test } from '..'
 
 test<{

--- a/test/typings/bigint.ts
+++ b/test/typings/bigint.ts
@@ -1,4 +1,4 @@
-import { assert, bigint } from '../../lib'
+import { assert, bigint } from '../../src'
 import { test } from '..'
 
 test<bigint>((x) => {

--- a/test/typings/boolean.ts
+++ b/test/typings/boolean.ts
@@ -1,4 +1,4 @@
-import { assert, boolean } from '../..'
+import { assert, boolean } from '../../src'
 import { test } from '..'
 
 test<boolean>((x) => {

--- a/test/typings/coerce.ts
+++ b/test/typings/coerce.ts
@@ -1,4 +1,4 @@
-import { assert, coerce, string, number } from '../..'
+import { assert, coerce, string, number } from '../../src'
 import { test } from '..'
 
 test<number>((x) => {

--- a/test/typings/date.ts
+++ b/test/typings/date.ts
@@ -1,4 +1,4 @@
-import { assert, date } from '../..'
+import { assert, date } from '../../src'
 import { test } from '..'
 
 test<Date>((x) => {

--- a/test/typings/defaulted.ts
+++ b/test/typings/defaulted.ts
@@ -1,4 +1,4 @@
-import { assert, defaulted, string } from '../..'
+import { assert, defaulted, string } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/deprecated.ts
+++ b/test/typings/deprecated.ts
@@ -1,4 +1,4 @@
-import { assert, object, deprecated, any, Context } from '../..'
+import { assert, object, deprecated, any, Context } from '../../src'
 import { test } from '..'
 
 test<unknown>((x) => {

--- a/test/typings/describe.ts
+++ b/test/typings/describe.ts
@@ -27,7 +27,7 @@ import {
   max,
   min,
   pattern,
-} from '../..'
+} from '../../src'
 import { test } from '..'
 
 test<Describe<any>>((x) => {

--- a/test/typings/dynamic.ts
+++ b/test/typings/dynamic.ts
@@ -1,4 +1,4 @@
-import { assert, dynamic, string } from '../..'
+import { assert, dynamic, string } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/empty.ts
+++ b/test/typings/empty.ts
@@ -1,4 +1,4 @@
-import { assert, empty, string, array, map, set } from '../..'
+import { assert, empty, string, array, map, set } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/enums.ts
+++ b/test/typings/enums.ts
@@ -1,4 +1,4 @@
-import { assert, enums } from '../..'
+import { assert, enums } from '../../src'
 import { test } from '..'
 
 test<'a' | 'b' | 'c'>((x) => {

--- a/test/typings/func.ts
+++ b/test/typings/func.ts
@@ -1,4 +1,4 @@
-import { assert, func } from '../..'
+import { assert, func } from '../../src'
 import { test } from '..'
 
 test<Function>((x) => {

--- a/test/typings/infer.ts
+++ b/test/typings/infer.ts
@@ -1,4 +1,4 @@
-import { Infer, object, number, string, assert } from '../..'
+import { Infer, object, number, string, assert } from '../../src'
 import { test } from '..'
 
 const Struct = object()

--- a/test/typings/instance.ts
+++ b/test/typings/instance.ts
@@ -1,4 +1,4 @@
-import { assert, instance } from '../..'
+import { assert, instance } from '../../src'
 import { test } from '..'
 
 test<Date>((x) => {

--- a/test/typings/integer.ts
+++ b/test/typings/integer.ts
@@ -1,4 +1,4 @@
-import { assert, integer } from '../..'
+import { assert, integer } from '../../src'
 import { test } from '..'
 
 test<number>((x) => {

--- a/test/typings/intersection.ts
+++ b/test/typings/intersection.ts
@@ -1,4 +1,4 @@
-import { assert, intersection, object, string } from '../..'
+import { assert, intersection, object, string } from '../../src'
 import { test } from '..'
 
 test<{ a: string; b: string }>((x) => {

--- a/test/typings/lazy.ts
+++ b/test/typings/lazy.ts
@@ -1,4 +1,4 @@
-import { assert, lazy, string } from '../..'
+import { assert, lazy, string } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/literal.ts
+++ b/test/typings/literal.ts
@@ -1,4 +1,4 @@
-import { assert, literal } from '../..'
+import { assert, literal } from '../../src'
 import { test } from '..'
 
 test<true>((x) => {

--- a/test/typings/map.ts
+++ b/test/typings/map.ts
@@ -1,4 +1,4 @@
-import { assert, map, string, number } from '../..'
+import { assert, map, string, number } from '../../src'
 import { test } from '..'
 
 test<Map<string, number>>((x) => {

--- a/test/typings/max.ts
+++ b/test/typings/max.ts
@@ -1,4 +1,4 @@
-import { assert, number, max } from '../..'
+import { assert, number, max } from '../../src'
 import { test } from '..'
 
 test<number>((x) => {

--- a/test/typings/min.ts
+++ b/test/typings/min.ts
@@ -1,4 +1,4 @@
-import { assert, number, min } from '../..'
+import { assert, number, min } from '../../src'
 import { test } from '..'
 
 test<number>((x) => {

--- a/test/typings/never.ts
+++ b/test/typings/never.ts
@@ -1,4 +1,4 @@
-import { assert, never } from '../..'
+import { assert, never } from '../../src'
 import { test } from '..'
 
 test<never>((x) => {

--- a/test/typings/nonempty.ts
+++ b/test/typings/nonempty.ts
@@ -1,4 +1,4 @@
-import { assert, nonempty, string, array, map, set } from '../../lib'
+import { assert, nonempty, string, array, map, set } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/nullable.ts
+++ b/test/typings/nullable.ts
@@ -1,4 +1,4 @@
-import { assert, nullable, string, object, enums } from '../..'
+import { assert, nullable, string, object, enums } from '../../src'
 import { test } from '..'
 
 test<string | null>((x) => {

--- a/test/typings/number.ts
+++ b/test/typings/number.ts
@@ -1,4 +1,4 @@
-import { assert, number } from '../..'
+import { assert, number } from '../../src'
 import { test } from '..'
 
 test<number>((x) => {

--- a/test/typings/object.ts
+++ b/test/typings/object.ts
@@ -1,4 +1,4 @@
-import { assert, object, number, string } from '../..'
+import { assert, object, number, string } from '../../src'
 import { test } from '..'
 
 test<Record<string, unknown>>((x) => {

--- a/test/typings/omit.ts
+++ b/test/typings/omit.ts
@@ -1,4 +1,4 @@
-import { assert, omit, object, number, string, type } from '../..'
+import { assert, omit, object, number, string, type } from '../../src'
 import { test } from '..'
 
 test<{

--- a/test/typings/optional.ts
+++ b/test/typings/optional.ts
@@ -1,4 +1,4 @@
-import { assert, optional, string, number, object, enums } from '../..'
+import { assert, optional, string, number, object, enums } from '../../src'
 import { test } from '..'
 
 test<string | undefined>((x) => {

--- a/test/typings/partial.ts
+++ b/test/typings/partial.ts
@@ -1,4 +1,4 @@
-import { assert, object, number } from '../..'
+import { assert, object, number } from '../../src'
 import { test } from '..'
 
 test<{ a?: number }>((x) => {

--- a/test/typings/pattern.ts
+++ b/test/typings/pattern.ts
@@ -1,4 +1,4 @@
-import { assert, pattern, string } from '../..'
+import { assert, pattern, string } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/pick.ts
+++ b/test/typings/pick.ts
@@ -1,4 +1,4 @@
-import { assert, pick, object, number, string } from '../..'
+import { assert, pick, object, number, string } from '../../src'
 import { test } from '..'
 
 test<{

--- a/test/typings/record.ts
+++ b/test/typings/record.ts
@@ -1,4 +1,4 @@
-import { assert, record, string, number } from '../..'
+import { assert, record, string, number } from '../../src'
 import { test } from '..'
 
 test<Record<string, number>>((x) => {

--- a/test/typings/refine.ts
+++ b/test/typings/refine.ts
@@ -1,4 +1,4 @@
-import { assert, refine, string } from '../..'
+import { assert, refine, string } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/regexp.ts
+++ b/test/typings/regexp.ts
@@ -1,4 +1,4 @@
-import { assert, regexp } from '../..'
+import { assert, regexp } from '../../src'
 import { test } from '..'
 
 test<RegExp>((x) => {

--- a/test/typings/set.ts
+++ b/test/typings/set.ts
@@ -1,4 +1,4 @@
-import { assert, set, string } from '../..'
+import { assert, set, string } from '../../src'
 import { test } from '..'
 
 test<Set<string>>((x) => {

--- a/test/typings/size.ts
+++ b/test/typings/size.ts
@@ -1,4 +1,4 @@
-import { assert, size, string, array, number, map, set } from '../..'
+import { assert, size, string, array, number, map, set } from '../../src'
 import { test } from '..'
 
 test<number>((x) => {

--- a/test/typings/string.ts
+++ b/test/typings/string.ts
@@ -1,4 +1,4 @@
-import { assert, string } from '../..'
+import { assert, string } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/struct.ts
+++ b/test/typings/struct.ts
@@ -1,4 +1,4 @@
-import { assert, define } from '../..'
+import { assert, define } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/trimmed.ts
+++ b/test/typings/trimmed.ts
@@ -1,4 +1,4 @@
-import { assert, string, trimmed } from '../..'
+import { assert, string, trimmed } from '../../src'
 import { test } from '..'
 
 test<string>((x) => {

--- a/test/typings/tuple.ts
+++ b/test/typings/tuple.ts
@@ -1,4 +1,4 @@
-import { assert, tuple, string, number, literal } from '../..'
+import { assert, tuple, string, number, literal } from '../../src'
 import { test } from '..'
 
 test<[string, number]>((x) => {

--- a/test/typings/type.ts
+++ b/test/typings/type.ts
@@ -1,4 +1,4 @@
-import { assert, type, number } from '../..'
+import { assert, type, number } from '../../src'
 import { test } from '..'
 
 test<{ a: number }>((x) => {

--- a/test/typings/union.ts
+++ b/test/typings/union.ts
@@ -1,4 +1,4 @@
-import { assert, union, object, string, literal } from '../..'
+import { assert, union, object, string, literal } from '../../src'
 import { test } from '..'
 
 test<{ a: string } | { b: string }>((x) => {

--- a/test/typings/unknown.ts
+++ b/test/typings/unknown.ts
@@ -1,4 +1,4 @@
-import { assert, unknown } from '../..'
+import { assert, unknown } from '../../src'
 import { test } from '..'
 
 test<unknown>((x) => {

--- a/test/validation/any/valid-number.ts
+++ b/test/validation/any/valid-number.ts
@@ -1,4 +1,4 @@
-import { any } from '../../..'
+import { any } from '../../../src'
 
 export const Struct = any()
 

--- a/test/validation/any/valid-string.ts
+++ b/test/validation/any/valid-string.ts
@@ -1,4 +1,4 @@
-import { any } from '../../..'
+import { any } from '../../../src'
 
 export const Struct = any()
 

--- a/test/validation/any/valid-undefined.ts
+++ b/test/validation/any/valid-undefined.ts
@@ -1,4 +1,4 @@
-import { any } from '../../..'
+import { any } from '../../../src'
 
 export const Struct = any()
 

--- a/test/validation/array/invalid-element-property.ts
+++ b/test/validation/array/invalid-element-property.ts
@@ -1,4 +1,4 @@
-import { array, object, string } from '../../..'
+import { array, object, string } from '../../../src'
 
 export const Struct = array(object({ id: string() }))
 

--- a/test/validation/array/invalid-element.ts
+++ b/test/validation/array/invalid-element.ts
@@ -1,4 +1,4 @@
-import { array, number } from '../../..'
+import { array, number } from '../../../src'
 
 export const Struct = array(number())
 

--- a/test/validation/array/invalid-opaque.ts
+++ b/test/validation/array/invalid-opaque.ts
@@ -1,4 +1,4 @@
-import { array } from '../../..'
+import { array } from '../../../src'
 
 export const Struct = array()
 

--- a/test/validation/array/invalid.ts
+++ b/test/validation/array/invalid.ts
@@ -1,4 +1,4 @@
-import { array, number } from '../../..'
+import { array, number } from '../../../src'
 
 export const Struct = array(number())
 

--- a/test/validation/array/valid-opaque.ts
+++ b/test/validation/array/valid-opaque.ts
@@ -1,4 +1,4 @@
-import { array } from '../../..'
+import { array } from '../../../src'
 
 export const Struct = array()
 

--- a/test/validation/array/valid.ts
+++ b/test/validation/array/valid.ts
@@ -1,4 +1,4 @@
-import { array, number } from '../../..'
+import { array, number } from '../../../src'
 
 export const Struct = array(number())
 

--- a/test/validation/assign/invalid-object.ts
+++ b/test/validation/assign/invalid-object.ts
@@ -1,4 +1,4 @@
-import { object, assign, string, number } from '../../../lib'
+import { object, assign, string, number } from '../../../src'
 
 const A = object({ a: string() })
 const B = object({ a: number(), b: number() })

--- a/test/validation/assign/invalid-type.ts
+++ b/test/validation/assign/invalid-type.ts
@@ -1,4 +1,4 @@
-import { type, object, assign, string, number } from '../../../lib'
+import { type, object, assign, string, number } from '../../../src'
 
 const A = type({ a: string() })
 const B = object({ a: number(), b: number() })

--- a/test/validation/assign/valid-object.ts
+++ b/test/validation/assign/valid-object.ts
@@ -1,4 +1,4 @@
-import { type, assign, string, number } from '../../..'
+import { type, assign, string, number } from '../../../src'
 
 const A = type({ a: string() })
 const B = type({ a: number(), b: number() })

--- a/test/validation/assign/valid-type.ts
+++ b/test/validation/assign/valid-type.ts
@@ -1,4 +1,4 @@
-import { type, object, assign, string, number } from '../../..'
+import { type, object, assign, string, number } from '../../../src'
 
 const A = type({ a: string() })
 const B = object({ b: number() })

--- a/test/validation/bigint/invalid-number.ts
+++ b/test/validation/bigint/invalid-number.ts
@@ -1,4 +1,4 @@
-import { bigint } from '../../../lib'
+import { bigint } from '../../../src'
 
 export const Struct = bigint()
 

--- a/test/validation/bigint/invalid.ts
+++ b/test/validation/bigint/invalid.ts
@@ -1,4 +1,4 @@
-import { bigint } from '../../../lib'
+import { bigint } from '../../../src'
 
 export const Struct = bigint()
 

--- a/test/validation/bigint/valid.ts
+++ b/test/validation/bigint/valid.ts
@@ -1,4 +1,4 @@
-import { bigint } from '../../../lib'
+import { bigint } from '../../../src'
 
 export const Struct = bigint()
 

--- a/test/validation/boolean/invalid.ts
+++ b/test/validation/boolean/invalid.ts
@@ -1,4 +1,4 @@
-import { boolean } from '../../..'
+import { boolean } from '../../../src'
 
 export const Struct = boolean()
 

--- a/test/validation/boolean/valid.ts
+++ b/test/validation/boolean/valid.ts
@@ -1,4 +1,4 @@
-import { boolean } from '../../..'
+import { boolean } from '../../../src'
 
 export const Struct = boolean()
 

--- a/test/validation/coerce/changed.ts
+++ b/test/validation/coerce/changed.ts
@@ -1,4 +1,4 @@
-import { string, unknown, coerce } from '../../..'
+import { string, unknown, coerce } from '../../../src'
 
 export const Struct = coerce(string(), unknown(), (x) =>
   x == null ? 'unknown' : x

--- a/test/validation/coerce/condition-not-met.ts
+++ b/test/validation/coerce/condition-not-met.ts
@@ -1,4 +1,4 @@
-import { string, number, coerce } from '../../..'
+import { string, number, coerce } from '../../../src'
 
 export const Struct = coerce(string(), number(), (x) => 'known')
 

--- a/test/validation/coerce/unchanged.ts
+++ b/test/validation/coerce/unchanged.ts
@@ -1,4 +1,4 @@
-import { string, unknown, coerce } from '../../..'
+import { string, unknown, coerce } from '../../../src'
 
 export const Struct = coerce(string(), unknown(), (x) =>
   x == null ? 'unknown' : x

--- a/test/validation/date/invalid-date.ts
+++ b/test/validation/date/invalid-date.ts
@@ -1,4 +1,4 @@
-import { date } from '../../..'
+import { date } from '../../../src'
 
 export const Struct = date()
 

--- a/test/validation/date/invalid.ts
+++ b/test/validation/date/invalid.ts
@@ -1,4 +1,4 @@
-import { date } from '../../..'
+import { date } from '../../../src'
 
 export const Struct = date()
 

--- a/test/validation/date/valid.ts
+++ b/test/validation/date/valid.ts
@@ -1,4 +1,4 @@
-import { date } from '../../..'
+import { date } from '../../../src'
 
 export const Struct = date()
 

--- a/test/validation/defaulted/function.ts
+++ b/test/validation/defaulted/function.ts
@@ -1,4 +1,4 @@
-import { number, defaulted } from '../../..'
+import { number, defaulted } from '../../../src'
 
 export const Struct = defaulted(number(), () => 42)
 

--- a/test/validation/defaulted/mixin.ts
+++ b/test/validation/defaulted/mixin.ts
@@ -1,4 +1,4 @@
-import { defaulted, string, object, number } from '../../..'
+import { defaulted, string, object, number } from '../../../src'
 
 export const Struct = defaulted(
   object({

--- a/test/validation/defaulted/nested-double.ts
+++ b/test/validation/defaulted/nested-double.ts
@@ -1,4 +1,4 @@
-import { defaulted, string, object } from '../../..'
+import { defaulted, string, object } from '../../../src'
 
 export const Struct = object({
   book: defaulted(

--- a/test/validation/defaulted/nested.ts
+++ b/test/validation/defaulted/nested.ts
@@ -1,4 +1,4 @@
-import { defaulted, string, object } from '../../..'
+import { defaulted, string, object } from '../../../src'
 
 export const Struct = object({
   title: defaulted(string(), 'Untitled'),

--- a/test/validation/defaulted/strict.ts
+++ b/test/validation/defaulted/strict.ts
@@ -1,4 +1,4 @@
-import { defaulted, string, type, number } from '../../..'
+import { defaulted, string, type, number } from '../../../src'
 
 export const Struct = defaulted(
   type({

--- a/test/validation/defaulted/value.ts
+++ b/test/validation/defaulted/value.ts
@@ -1,4 +1,4 @@
-import { number, defaulted } from '../../..'
+import { number, defaulted } from '../../../src'
 
 export const Struct = defaulted(number(), 42)
 

--- a/test/validation/deprecated/invalid-null.ts
+++ b/test/validation/deprecated/invalid-null.ts
@@ -1,4 +1,4 @@
-import { deprecated, string } from '../../..'
+import { deprecated, string } from '../../../src'
 
 export const Struct = deprecated(string(), () => {})
 

--- a/test/validation/deprecated/invalid-property.ts
+++ b/test/validation/deprecated/invalid-property.ts
@@ -1,4 +1,4 @@
-import { deprecated, number, object } from '../../..'
+import { deprecated, number, object } from '../../../src'
 
 export const Struct = object({
   deprecatedKey: deprecated(number(), () => {}),

--- a/test/validation/deprecated/invalid.ts
+++ b/test/validation/deprecated/invalid.ts
@@ -1,4 +1,4 @@
-import { deprecated, number } from '../../..'
+import { deprecated, number } from '../../../src'
 
 export const Struct = deprecated(number(), () => {})
 

--- a/test/validation/deprecated/valid-property.ts
+++ b/test/validation/deprecated/valid-property.ts
@@ -1,4 +1,4 @@
-import { type, number, deprecated, any } from '../../..'
+import { type, number, deprecated, any } from '../../../src'
 
 export const Struct = type({
   name: deprecated(any(), () => {}),

--- a/test/validation/deprecated/valid-undefined.ts
+++ b/test/validation/deprecated/valid-undefined.ts
@@ -1,4 +1,4 @@
-import { deprecated, number } from '../../..'
+import { deprecated, number } from '../../../src'
 
 export const Struct = deprecated(number(), () => {})
 

--- a/test/validation/deprecated/valid.ts
+++ b/test/validation/deprecated/valid.ts
@@ -1,4 +1,4 @@
-import { deprecated, number } from '../../..'
+import { deprecated, number } from '../../../src'
 
 export const Struct = deprecated(number(), () => {})
 

--- a/test/validation/dynamic/invalid-reference.ts
+++ b/test/validation/dynamic/invalid-reference.ts
@@ -1,4 +1,4 @@
-import { assert, type, dynamic, literal, number, string } from '../../..'
+import { assert, type, dynamic, literal, number, string } from '../../../src'
 
 const Entity = type({
   object: string(),

--- a/test/validation/dynamic/invalid.ts
+++ b/test/validation/dynamic/invalid.ts
@@ -1,4 +1,4 @@
-import { dynamic, string } from '../../..'
+import { dynamic, string } from '../../../src'
 
 export const Struct = dynamic(() => string())
 

--- a/test/validation/dynamic/valid-reference.ts
+++ b/test/validation/dynamic/valid-reference.ts
@@ -1,4 +1,4 @@
-import { assert, type, dynamic, literal, string, number } from '../../..'
+import { assert, type, dynamic, literal, string, number } from '../../../src'
 
 const Entity = type({
   object: string(),

--- a/test/validation/dynamic/valid.ts
+++ b/test/validation/dynamic/valid.ts
@@ -1,4 +1,4 @@
-import { dynamic, string } from '../../..'
+import { dynamic, string } from '../../../src'
 
 export const Struct = dynamic(() => string())
 

--- a/test/validation/dynamic/with-refiners.ts
+++ b/test/validation/dynamic/with-refiners.ts
@@ -1,4 +1,4 @@
-import { dynamic, string, nonempty } from '../../..'
+import { dynamic, string, nonempty } from '../../../src'
 
 export const Struct = dynamic(() => nonempty(string()))
 

--- a/test/validation/empty/invalid-array.ts
+++ b/test/validation/empty/invalid-array.ts
@@ -1,4 +1,4 @@
-import { array, empty, number } from '../../..'
+import { array, empty, number } from '../../../src'
 
 export const Struct = empty(array(number()))
 

--- a/test/validation/empty/invalid-map.ts
+++ b/test/validation/empty/invalid-map.ts
@@ -1,4 +1,4 @@
-import { map, empty, number, string } from '../../..'
+import { map, empty, number, string } from '../../../src'
 
 export const Struct = empty(map(number(), string()))
 

--- a/test/validation/empty/invalid-set.ts
+++ b/test/validation/empty/invalid-set.ts
@@ -1,4 +1,4 @@
-import { set, empty, number } from '../../..'
+import { set, empty, number } from '../../../src'
 
 export const Struct = empty(set(number()))
 

--- a/test/validation/empty/invalid-string.ts
+++ b/test/validation/empty/invalid-string.ts
@@ -1,4 +1,4 @@
-import { string, empty } from '../../..'
+import { string, empty } from '../../../src'
 
 export const Struct = empty(string())
 

--- a/test/validation/empty/valid-array.ts
+++ b/test/validation/empty/valid-array.ts
@@ -1,4 +1,4 @@
-import { number, array, empty } from '../../..'
+import { number, array, empty } from '../../../src'
 
 export const Struct = empty(array(number()))
 

--- a/test/validation/empty/valid-map.ts
+++ b/test/validation/empty/valid-map.ts
@@ -1,4 +1,4 @@
-import { string, number, map, empty } from '../../..'
+import { string, number, map, empty } from '../../../src'
 
 export const Struct = empty(map(number(), string()))
 

--- a/test/validation/empty/valid-set.ts
+++ b/test/validation/empty/valid-set.ts
@@ -1,4 +1,4 @@
-import { number, set, empty } from '../../..'
+import { number, set, empty } from '../../../src'
 
 export const Struct = empty(set(number()))
 

--- a/test/validation/empty/valid-string.ts
+++ b/test/validation/empty/valid-string.ts
@@ -1,4 +1,4 @@
-import { string, empty } from '../../..'
+import { string, empty } from '../../../src'
 
 export const Struct = empty(string())
 

--- a/test/validation/enums/invalid-numbers.ts
+++ b/test/validation/enums/invalid-numbers.ts
@@ -1,4 +1,4 @@
-import { enums } from '../../..'
+import { enums } from '../../../src'
 
 export const Struct = enums([1, 2])
 

--- a/test/validation/enums/invalid-strings.ts
+++ b/test/validation/enums/invalid-strings.ts
@@ -1,4 +1,4 @@
-import { enums } from '../../..'
+import { enums } from '../../../src'
 
 export const Struct = enums(['one', 'two'])
 

--- a/test/validation/enums/valid.ts
+++ b/test/validation/enums/valid.ts
@@ -1,4 +1,4 @@
-import { enums } from '../../..'
+import { enums } from '../../../src'
 
 export const Struct = enums(['one', 'two'])
 

--- a/test/validation/function/invalid.ts
+++ b/test/validation/function/invalid.ts
@@ -1,4 +1,4 @@
-import { func } from '../../..'
+import { func } from '../../../src'
 
 export const Struct = func()
 

--- a/test/validation/function/valid.ts
+++ b/test/validation/function/valid.ts
@@ -1,4 +1,4 @@
-import { func } from '../../..'
+import { func } from '../../../src'
 
 export const Struct = func()
 

--- a/test/validation/instance/invalid.ts
+++ b/test/validation/instance/invalid.ts
@@ -1,4 +1,4 @@
-import { instance } from '../../..'
+import { instance } from '../../../src'
 
 export const Struct = instance(Array)
 

--- a/test/validation/instance/valid.ts
+++ b/test/validation/instance/valid.ts
@@ -1,4 +1,4 @@
-import { instance } from '../../..'
+import { instance } from '../../../src'
 
 export const Struct = instance(Array)
 

--- a/test/validation/integer/invalid-decimal.ts
+++ b/test/validation/integer/invalid-decimal.ts
@@ -1,4 +1,4 @@
-import { integer } from '../../..'
+import { integer } from '../../../src'
 
 export const Struct = integer()
 

--- a/test/validation/integer/invalid.ts
+++ b/test/validation/integer/invalid.ts
@@ -1,4 +1,4 @@
-import { integer } from '../../..'
+import { integer } from '../../../src'
 
 export const Struct = integer()
 

--- a/test/validation/integer/valid.ts
+++ b/test/validation/integer/valid.ts
@@ -1,4 +1,4 @@
-import { integer } from '../../..'
+import { integer } from '../../../src'
 
 export const Struct = integer()
 

--- a/test/validation/intersection/invalid-refinement.ts
+++ b/test/validation/intersection/invalid-refinement.ts
@@ -1,4 +1,4 @@
-import { intersection, refine, number } from '../../..'
+import { intersection, refine, number } from '../../../src'
 
 const A = number()
 const B = refine(number(), 'positive', (value) => value > 0)

--- a/test/validation/intersection/invalid.ts
+++ b/test/validation/intersection/invalid.ts
@@ -1,4 +1,4 @@
-import { type, intersection, string, number } from '../../..'
+import { type, intersection, string, number } from '../../../src'
 
 const A = type({ a: string() })
 const B = type({ b: number() })

--- a/test/validation/intersection/valid-refinement.ts
+++ b/test/validation/intersection/valid-refinement.ts
@@ -1,4 +1,4 @@
-import { intersection, refine, number } from '../../..'
+import { intersection, refine, number } from '../../../src'
 
 const A = number()
 const B = refine(number(), 'positive', (value) => value > 0)

--- a/test/validation/intersection/valid.ts
+++ b/test/validation/intersection/valid.ts
@@ -1,4 +1,4 @@
-import { type, intersection, string, number } from '../../..'
+import { type, intersection, string, number } from '../../../src'
 
 const A = type({ a: string() })
 const B = type({ b: number() })

--- a/test/validation/lazy/invalid.ts
+++ b/test/validation/lazy/invalid.ts
@@ -1,4 +1,4 @@
-import { lazy, string } from '../../..'
+import { lazy, string } from '../../../src'
 
 export const Struct = lazy(() => string())
 

--- a/test/validation/lazy/valid.ts
+++ b/test/validation/lazy/valid.ts
@@ -1,4 +1,4 @@
-import { lazy, string } from '../../..'
+import { lazy, string } from '../../../src'
 
 export const Struct = lazy(() => string())
 

--- a/test/validation/lazy/with-refiners.ts
+++ b/test/validation/lazy/with-refiners.ts
@@ -1,4 +1,4 @@
-import { lazy, nonempty, string } from '../../..'
+import { lazy, nonempty, string } from '../../../src'
 
 export const Struct = lazy(() => nonempty(string()))
 

--- a/test/validation/literal/invalid.ts
+++ b/test/validation/literal/invalid.ts
@@ -1,4 +1,4 @@
-import { literal } from '../../..'
+import { literal } from '../../../src'
 
 export const Struct = literal(42)
 

--- a/test/validation/literal/valid.ts
+++ b/test/validation/literal/valid.ts
@@ -1,4 +1,4 @@
-import { literal } from '../../..'
+import { literal } from '../../../src'
 
 export const Struct = literal(42)
 

--- a/test/validation/map/invalid-opaque.ts
+++ b/test/validation/map/invalid-opaque.ts
@@ -1,4 +1,4 @@
-import { map } from '../../..'
+import { map } from '../../../src'
 
 export const Struct = map()
 

--- a/test/validation/map/invalid-property.ts
+++ b/test/validation/map/invalid-property.ts
@@ -1,4 +1,4 @@
-import { map, string, number } from '../../..'
+import { map, string, number } from '../../../src'
 
 export const Struct = map(string(), number())
 

--- a/test/validation/map/invalid.ts
+++ b/test/validation/map/invalid.ts
@@ -1,4 +1,4 @@
-import { map, string, number } from '../../..'
+import { map, string, number } from '../../../src'
 
 export const Struct = map(string(), number())
 

--- a/test/validation/map/valid-opaque.ts
+++ b/test/validation/map/valid-opaque.ts
@@ -1,4 +1,4 @@
-import { map } from '../../..'
+import { map } from '../../../src'
 
 export const Struct = map()
 

--- a/test/validation/map/valid.ts
+++ b/test/validation/map/valid.ts
@@ -1,4 +1,4 @@
-import { map, string, number } from '../../..'
+import { map, string, number } from '../../../src'
 
 export const Struct = map(string(), number())
 

--- a/test/validation/max/invalid-exclusive.ts
+++ b/test/validation/max/invalid-exclusive.ts
@@ -1,4 +1,4 @@
-import { number, max } from '../../..'
+import { number, max } from '../../../src'
 
 export const Struct = max(number(), 0, { exclusive: true })
 

--- a/test/validation/max/invalid.ts
+++ b/test/validation/max/invalid.ts
@@ -1,4 +1,4 @@
-import { number, max } from '../../..'
+import { number, max } from '../../../src'
 
 export const Struct = max(number(), 0)
 

--- a/test/validation/max/valid-inclusive.ts
+++ b/test/validation/max/valid-inclusive.ts
@@ -1,4 +1,4 @@
-import { number, max } from '../../..'
+import { number, max } from '../../../src'
 
 export const Struct = max(number(), 0)
 

--- a/test/validation/max/valid.ts
+++ b/test/validation/max/valid.ts
@@ -1,4 +1,4 @@
-import { number, max } from '../../..'
+import { number, max } from '../../../src'
 
 export const Struct = max(number(), 0)
 

--- a/test/validation/min/invalid-exclusive.ts
+++ b/test/validation/min/invalid-exclusive.ts
@@ -1,4 +1,4 @@
-import { number, min } from '../../..'
+import { number, min } from '../../../src'
 
 export const Struct = min(number(), 0, { exclusive: true })
 

--- a/test/validation/min/invalid.ts
+++ b/test/validation/min/invalid.ts
@@ -1,4 +1,4 @@
-import { number, min } from '../../..'
+import { number, min } from '../../../src'
 
 export const Struct = min(number(), 0)
 

--- a/test/validation/min/valid-inclusive.ts
+++ b/test/validation/min/valid-inclusive.ts
@@ -1,4 +1,4 @@
-import { number, min } from '../../..'
+import { number, min } from '../../../src'
 
 export const Struct = min(number(), 0)
 

--- a/test/validation/min/valid.ts
+++ b/test/validation/min/valid.ts
@@ -1,4 +1,4 @@
-import { number, min } from '../../..'
+import { number, min } from '../../../src'
 
 export const Struct = min(number(), 0)
 

--- a/test/validation/never/invalid.ts
+++ b/test/validation/never/invalid.ts
@@ -1,4 +1,4 @@
-import { never } from '../../..'
+import { never } from '../../../src'
 
 export const Struct = never()
 

--- a/test/validation/nullable/invalid.ts
+++ b/test/validation/nullable/invalid.ts
@@ -1,4 +1,4 @@
-import { number, nullable } from '../../..'
+import { number, nullable } from '../../../src'
 
 export const Struct = nullable(number())
 

--- a/test/validation/nullable/valid-defined-nested.ts
+++ b/test/validation/nullable/valid-defined-nested.ts
@@ -1,4 +1,4 @@
-import { type, string, number, nullable } from '../../..'
+import { type, string, number, nullable } from '../../../src'
 
 export const Struct = type({
   name: nullable(string()),

--- a/test/validation/nullable/valid-defined.ts
+++ b/test/validation/nullable/valid-defined.ts
@@ -1,4 +1,4 @@
-import { number, nullable } from '../../..'
+import { number, nullable } from '../../../src'
 
 export const Struct = nullable(number())
 

--- a/test/validation/nullable/valid-null-nested.ts
+++ b/test/validation/nullable/valid-null-nested.ts
@@ -1,4 +1,4 @@
-import { type, string, number, nullable } from '../../..'
+import { type, string, number, nullable } from '../../../src'
 
 export const Struct = type({
   name: nullable(string()),

--- a/test/validation/nullable/valid-null.ts
+++ b/test/validation/nullable/valid-null.ts
@@ -1,4 +1,4 @@
-import { number, nullable } from '../../..'
+import { number, nullable } from '../../../src'
 
 export const Struct = nullable(number())
 

--- a/test/validation/number/invalid.ts
+++ b/test/validation/number/invalid.ts
@@ -1,4 +1,4 @@
-import { number } from '../../..'
+import { number } from '../../../src'
 
 export const Struct = number()
 

--- a/test/validation/number/valid.ts
+++ b/test/validation/number/valid.ts
@@ -1,4 +1,4 @@
-import { number } from '../../..'
+import { number } from '../../../src'
 
 export const Struct = number()
 

--- a/test/validation/object/invalid-element-nested.ts
+++ b/test/validation/object/invalid-element-nested.ts
@@ -1,4 +1,4 @@
-import { object, array, string } from '../../..'
+import { object, array, string } from '../../../src'
 
 export const Struct = object({
   name: string(),

--- a/test/validation/object/invalid-opaque.ts
+++ b/test/validation/object/invalid-opaque.ts
@@ -1,4 +1,4 @@
-import { object } from '../../..'
+import { object } from '../../../src'
 
 export const Struct = object()
 

--- a/test/validation/object/invalid-property-nested.ts
+++ b/test/validation/object/invalid-property-nested.ts
@@ -1,4 +1,4 @@
-import { object, string } from '../../..'
+import { object, string } from '../../../src'
 
 export const Struct = object({
   name: string(),

--- a/test/validation/object/invalid-property-unknown.ts
+++ b/test/validation/object/invalid-property-unknown.ts
@@ -1,4 +1,4 @@
-import { object, string, number } from '../../..'
+import { object, string, number } from '../../../src'
 
 export const Struct = object({
   name: string(),

--- a/test/validation/object/invalid-property.ts
+++ b/test/validation/object/invalid-property.ts
@@ -1,4 +1,4 @@
-import { object, string, number } from '../../..'
+import { object, string, number } from '../../../src'
 
 export const Struct = object({
   name: string(),

--- a/test/validation/object/invalid-referential.ts
+++ b/test/validation/object/invalid-referential.ts
@@ -1,4 +1,4 @@
-import { object, string, pattern, refine } from '../../..'
+import { object, string, pattern, refine } from '../../../src'
 
 const Section = pattern(string(), /^\d+(\.\d+)*$/)
 

--- a/test/validation/object/invalid.ts
+++ b/test/validation/object/invalid.ts
@@ -1,4 +1,4 @@
-import { object, string, number } from '../../..'
+import { object, string, number } from '../../../src'
 
 export const Struct = object({
   name: string(),

--- a/test/validation/object/valid-nested.ts
+++ b/test/validation/object/valid-nested.ts
@@ -1,4 +1,4 @@
-import { object, string } from '../../..'
+import { object, string } from '../../../src'
 
 export const Struct = object({
   name: string(),

--- a/test/validation/object/valid-opaque.ts
+++ b/test/validation/object/valid-opaque.ts
@@ -1,4 +1,4 @@
-import { object } from '../../..'
+import { object } from '../../../src'
 
 export const Struct = object()
 

--- a/test/validation/object/valid-referential.ts
+++ b/test/validation/object/valid-referential.ts
@@ -1,4 +1,4 @@
-import { object, string, pattern, refine } from '../../..'
+import { object, string, pattern, refine } from '../../../src'
 
 const Section = pattern(string(), /^\d+(\.\d+)*$/)
 

--- a/test/validation/object/valid.ts
+++ b/test/validation/object/valid.ts
@@ -1,4 +1,4 @@
-import { object, string, number } from '../../..'
+import { object, string, number } from '../../../src'
 
 export const Struct = object({
   name: string(),

--- a/test/validation/omit/invalid-element-nested.ts
+++ b/test/validation/omit/invalid-element-nested.ts
@@ -1,4 +1,4 @@
-import { omit, object, array, string } from '../../..'
+import { omit, object, array, string } from '../../../src'
 
 export const Struct = omit(
   object({

--- a/test/validation/omit/invalid-property-nested.ts
+++ b/test/validation/omit/invalid-property-nested.ts
@@ -1,4 +1,4 @@
-import { omit, object, string } from '../../..'
+import { omit, object, string } from '../../../src'
 
 export const Struct = omit(
   object({

--- a/test/validation/omit/invalid-property-unknown.ts
+++ b/test/validation/omit/invalid-property-unknown.ts
@@ -1,4 +1,4 @@
-import { omit, object, string, number } from '../../..'
+import { omit, object, string, number } from '../../../src'
 
 export const Struct = omit(
   object({

--- a/test/validation/omit/invalid-property.ts
+++ b/test/validation/omit/invalid-property.ts
@@ -1,4 +1,4 @@
-import { omit, object, string, number } from '../../..'
+import { omit, object, string, number } from '../../../src'
 
 export const Struct = omit(
   object({

--- a/test/validation/omit/invalid.ts
+++ b/test/validation/omit/invalid.ts
@@ -1,4 +1,4 @@
-import { omit, object, string, number } from '../../..'
+import { omit, object, string, number } from '../../../src'
 
 export const Struct = omit(
   object({

--- a/test/validation/omit/valid-nested.ts
+++ b/test/validation/omit/valid-nested.ts
@@ -1,4 +1,4 @@
-import { omit, object, string } from '../../..'
+import { omit, object, string } from '../../../src'
 
 export const Struct = omit(
   object({

--- a/test/validation/omit/valid-type.ts
+++ b/test/validation/omit/valid-type.ts
@@ -1,4 +1,4 @@
-import { omit, type, string, number } from '../../../lib'
+import { omit, type, string, number } from '../../../src'
 
 export const Struct = omit(
   type({

--- a/test/validation/omit/valid.ts
+++ b/test/validation/omit/valid.ts
@@ -1,4 +1,4 @@
-import { omit, object, string, number } from '../../..'
+import { omit, object, string, number } from '../../../src'
 
 export const Struct = omit(
   object({

--- a/test/validation/optional/invalid.ts
+++ b/test/validation/optional/invalid.ts
@@ -1,4 +1,4 @@
-import { number, optional } from '../../..'
+import { number, optional } from '../../../src'
 
 export const Struct = optional(number())
 

--- a/test/validation/optional/valid-defined-nested.ts
+++ b/test/validation/optional/valid-defined-nested.ts
@@ -1,4 +1,4 @@
-import { type, string, number, optional } from '../../..'
+import { type, string, number, optional } from '../../../src'
 
 export const Struct = type({
   name: optional(string()),

--- a/test/validation/optional/valid-defined.ts
+++ b/test/validation/optional/valid-defined.ts
@@ -1,4 +1,4 @@
-import { number, optional } from '../../..'
+import { number, optional } from '../../../src'
 
 export const Struct = optional(number())
 

--- a/test/validation/optional/valid-undefined-nested.ts
+++ b/test/validation/optional/valid-undefined-nested.ts
@@ -1,4 +1,4 @@
-import { type, string, number, optional } from '../../..'
+import { type, string, number, optional } from '../../../src'
 
 export const Struct = type({
   name: optional(string()),

--- a/test/validation/optional/valid-undefined.ts
+++ b/test/validation/optional/valid-undefined.ts
@@ -1,4 +1,4 @@
-import { number, optional } from '../../..'
+import { number, optional } from '../../../src'
 
 export const Struct = optional(number())
 

--- a/test/validation/partial/composed.ts
+++ b/test/validation/partial/composed.ts
@@ -1,4 +1,4 @@
-import { partial, object, string, number } from '../../..'
+import { partial, object, string, number } from '../../../src'
 
 export const Struct = partial(
   object({

--- a/test/validation/partial/invalid-property-unknown.ts
+++ b/test/validation/partial/invalid-property-unknown.ts
@@ -1,4 +1,4 @@
-import { partial, string, number } from '../../..'
+import { partial, string, number } from '../../../src'
 
 export const Struct = partial({
   name: string(),

--- a/test/validation/partial/invalid-property.ts
+++ b/test/validation/partial/invalid-property.ts
@@ -1,4 +1,4 @@
-import { partial, string, number } from '../../..'
+import { partial, string, number } from '../../../src'
 
 export const Struct = partial({
   name: string(),

--- a/test/validation/partial/invalid.ts
+++ b/test/validation/partial/invalid.ts
@@ -1,4 +1,4 @@
-import { partial, string, number } from '../../..'
+import { partial, string, number } from '../../../src'
 
 export const Struct = partial({
   name: string(),

--- a/test/validation/partial/valid-empty.ts
+++ b/test/validation/partial/valid-empty.ts
@@ -1,4 +1,4 @@
-import { partial, string, number } from '../../..'
+import { partial, string, number } from '../../../src'
 
 export const Struct = partial({
   name: string(),

--- a/test/validation/partial/valid-full.ts
+++ b/test/validation/partial/valid-full.ts
@@ -1,4 +1,4 @@
-import { partial, string, number } from '../../..'
+import { partial, string, number } from '../../../src'
 
 export const Struct = partial({
   name: string(),

--- a/test/validation/partial/valid-partial.ts
+++ b/test/validation/partial/valid-partial.ts
@@ -1,4 +1,4 @@
-import { partial, string, number } from '../../..'
+import { partial, string, number } from '../../../src'
 
 export const Struct = partial({
   name: string(),

--- a/test/validation/pattern/invalid.ts
+++ b/test/validation/pattern/invalid.ts
@@ -1,4 +1,4 @@
-import { string, pattern } from '../../..'
+import { string, pattern } from '../../../src'
 
 export const Struct = pattern(string(), /\d+/)
 

--- a/test/validation/pattern/valid.ts
+++ b/test/validation/pattern/valid.ts
@@ -1,4 +1,4 @@
-import { string, pattern } from '../../..'
+import { string, pattern } from '../../../src'
 
 export const Struct = pattern(string(), /\d+/)
 

--- a/test/validation/pick/invalid-element-nested.ts
+++ b/test/validation/pick/invalid-element-nested.ts
@@ -1,4 +1,4 @@
-import { pick, object, array, string } from '../../..'
+import { pick, object, array, string } from '../../../src'
 
 export const Struct = pick(
   object({

--- a/test/validation/pick/invalid-property-nested.ts
+++ b/test/validation/pick/invalid-property-nested.ts
@@ -1,4 +1,4 @@
-import { pick, object, string } from '../../..'
+import { pick, object, string } from '../../../src'
 
 export const Struct = pick(
   object({

--- a/test/validation/pick/invalid-property-unknown.ts
+++ b/test/validation/pick/invalid-property-unknown.ts
@@ -1,4 +1,4 @@
-import { pick, object, string, number } from '../../..'
+import { pick, object, string, number } from '../../../src'
 
 export const Struct = pick(
   object({

--- a/test/validation/pick/invalid-property.ts
+++ b/test/validation/pick/invalid-property.ts
@@ -1,4 +1,4 @@
-import { pick, object, string, number } from '../../..'
+import { pick, object, string, number } from '../../../src'
 
 export const Struct = pick(
   object({

--- a/test/validation/pick/invalid.ts
+++ b/test/validation/pick/invalid.ts
@@ -1,4 +1,4 @@
-import { pick, object, string, number } from '../../..'
+import { pick, object, string, number } from '../../../src'
 
 export const Struct = pick(
   object({

--- a/test/validation/pick/valid-nested.ts
+++ b/test/validation/pick/valid-nested.ts
@@ -1,4 +1,4 @@
-import { pick, object, string } from '../../..'
+import { pick, object, string } from '../../../src'
 
 export const Struct = pick(
   object({

--- a/test/validation/pick/valid.ts
+++ b/test/validation/pick/valid.ts
@@ -1,4 +1,4 @@
-import { pick, object, string, number } from '../../..'
+import { pick, object, string, number } from '../../../src'
 
 export const Struct = pick(
   object({

--- a/test/validation/record/invalid-property.ts
+++ b/test/validation/record/invalid-property.ts
@@ -1,4 +1,4 @@
-import { record, string, number } from '../../..'
+import { record, string, number } from '../../../src'
 
 export const Struct = record(string(), number())
 

--- a/test/validation/record/invalid.ts
+++ b/test/validation/record/invalid.ts
@@ -1,4 +1,4 @@
-import { record, string, number } from '../../..'
+import { record, string, number } from '../../../src'
 
 export const Struct = record(string(), number())
 

--- a/test/validation/record/valid.ts
+++ b/test/validation/record/valid.ts
@@ -1,4 +1,4 @@
-import { record, string, number } from '../../..'
+import { record, string, number } from '../../../src'
 
 export const Struct = record(string(), number())
 

--- a/test/validation/refine/invalid-multiple-refinements.ts
+++ b/test/validation/refine/invalid-multiple-refinements.ts
@@ -1,4 +1,4 @@
-import { string, refine, object } from '../../..'
+import { string, refine, object } from '../../../src'
 
 const PasswordValidator = refine(string(), 'MinimumLength', (pw) =>
   pw.length >= 8 ? true : 'required minimum length of 8'

--- a/test/validation/refine/invalid-shorthand.ts
+++ b/test/validation/refine/invalid-shorthand.ts
@@ -1,4 +1,4 @@
-import { number, refine } from '../../..'
+import { number, refine } from '../../../src'
 
 export const Struct = refine(
   number(),

--- a/test/validation/refine/invalid.ts
+++ b/test/validation/refine/invalid.ts
@@ -1,5 +1,5 @@
 import isEmail from 'is-email'
-import { string, refine } from '../../..'
+import { string, refine } from '../../../src'
 
 export const Struct = refine(string(), 'email', isEmail)
 

--- a/test/validation/refine/valid.ts
+++ b/test/validation/refine/valid.ts
@@ -1,5 +1,5 @@
 import isEmail from 'is-email'
-import { string, refine } from '../../..'
+import { string, refine } from '../../../src'
 
 export const Struct = refine(string(), 'email', isEmail)
 

--- a/test/validation/regexp/invalid.ts
+++ b/test/validation/regexp/invalid.ts
@@ -1,4 +1,4 @@
-import { regexp } from '../../..'
+import { regexp } from '../../../src'
 
 export const Struct = regexp()
 

--- a/test/validation/regexp/valid.ts
+++ b/test/validation/regexp/valid.ts
@@ -1,4 +1,4 @@
-import { regexp } from '../../..'
+import { regexp } from '../../../src'
 
 export const Struct = regexp()
 

--- a/test/validation/set/invalid-element.ts
+++ b/test/validation/set/invalid-element.ts
@@ -1,4 +1,4 @@
-import { set, number } from '../../..'
+import { set, number } from '../../../src'
 
 export const Struct = set(number())
 

--- a/test/validation/set/invalid-opaque.ts
+++ b/test/validation/set/invalid-opaque.ts
@@ -1,4 +1,4 @@
-import { set } from '../../..'
+import { set } from '../../../src'
 
 export const Struct = set()
 

--- a/test/validation/set/invalid.ts
+++ b/test/validation/set/invalid.ts
@@ -1,4 +1,4 @@
-import { set, number } from '../../..'
+import { set, number } from '../../../src'
 
 export const Struct = set(number())
 

--- a/test/validation/set/valid-opaque.ts
+++ b/test/validation/set/valid-opaque.ts
@@ -1,4 +1,4 @@
-import { set } from '../../..'
+import { set } from '../../../src'
 
 export const Struct = set()
 

--- a/test/validation/set/valid.ts
+++ b/test/validation/set/valid.ts
@@ -1,4 +1,4 @@
-import { set, number } from '../../..'
+import { set, number } from '../../../src'
 
 export const Struct = set(number())
 

--- a/test/validation/size/invalid-array.ts
+++ b/test/validation/size/invalid-array.ts
@@ -1,4 +1,4 @@
-import { array, size, number } from '../../..'
+import { array, size, number } from '../../../src'
 
 export const Struct = size(array(number()), 1, 5)
 

--- a/test/validation/size/invalid-map.ts
+++ b/test/validation/size/invalid-map.ts
@@ -1,4 +1,4 @@
-import { map, size, number, string } from '../../..'
+import { map, size, number, string } from '../../../src'
 
 export const Struct = size(map(number(), string()), 1, 5)
 

--- a/test/validation/size/invalid-number.ts
+++ b/test/validation/size/invalid-number.ts
@@ -1,4 +1,4 @@
-import { number, size } from '../../..'
+import { number, size } from '../../../src'
 
 export const Struct = size(number(), 1, 5)
 

--- a/test/validation/size/invalid-set.ts
+++ b/test/validation/size/invalid-set.ts
@@ -1,4 +1,4 @@
-import { set, size, number } from '../../..'
+import { set, size, number } from '../../../src'
 
 export const Struct = size(set(number()), 1, 5)
 

--- a/test/validation/size/invalid-string.ts
+++ b/test/validation/size/invalid-string.ts
@@ -1,4 +1,4 @@
-import { string, size } from '../../..'
+import { string, size } from '../../../src'
 
 export const Struct = size(string(), 1, 5)
 

--- a/test/validation/size/valid-array.ts
+++ b/test/validation/size/valid-array.ts
@@ -1,4 +1,4 @@
-import { number, array, size } from '../../..'
+import { number, array, size } from '../../../src'
 
 export const Struct = size(array(number()), 1, 5)
 

--- a/test/validation/size/valid-exact.ts
+++ b/test/validation/size/valid-exact.ts
@@ -1,4 +1,4 @@
-import { string, size } from '../../..'
+import { string, size } from '../../../src'
 
 export const Struct = size(string(), 4)
 

--- a/test/validation/size/valid-map.ts
+++ b/test/validation/size/valid-map.ts
@@ -1,4 +1,4 @@
-import { string, number, map, size } from '../../..'
+import { string, number, map, size } from '../../../src'
 
 export const Struct = size(map(number(), string()), 1, 5)
 

--- a/test/validation/size/valid-max-inclusive.ts
+++ b/test/validation/size/valid-max-inclusive.ts
@@ -1,4 +1,4 @@
-import { string, size } from '../../..'
+import { string, size } from '../../../src'
 
 export const Struct = size(string(), 1, 5)
 

--- a/test/validation/size/valid-min-inclusive.ts
+++ b/test/validation/size/valid-min-inclusive.ts
@@ -1,4 +1,4 @@
-import { string, size } from '../../..'
+import { string, size } from '../../../src'
 
 export const Struct = size(string(), 1, 5)
 

--- a/test/validation/size/valid-number.ts
+++ b/test/validation/size/valid-number.ts
@@ -1,4 +1,4 @@
-import { number, size } from '../../..'
+import { number, size } from '../../../src'
 
 export const Struct = size(number(), 1, 5)
 

--- a/test/validation/size/valid-set.ts
+++ b/test/validation/size/valid-set.ts
@@ -1,4 +1,4 @@
-import { number, set, size } from '../../..'
+import { number, set, size } from '../../../src'
 
 export const Struct = size(set(number()), 1, 5)
 

--- a/test/validation/size/valid-string.ts
+++ b/test/validation/size/valid-string.ts
@@ -1,4 +1,4 @@
-import { string, size } from '../../..'
+import { string, size } from '../../../src'
 
 export const Struct = size(string(), 1, 5)
 

--- a/test/validation/string/invalid.ts
+++ b/test/validation/string/invalid.ts
@@ -1,4 +1,4 @@
-import { string } from '../../..'
+import { string } from '../../../src'
 
 export const Struct = string()
 

--- a/test/validation/string/valid.ts
+++ b/test/validation/string/valid.ts
@@ -1,4 +1,4 @@
-import { string } from '../../..'
+import { string } from '../../../src'
 
 export const Struct = string()
 

--- a/test/validation/trimmed/invalid.ts
+++ b/test/validation/trimmed/invalid.ts
@@ -1,4 +1,4 @@
-import { string, trimmed } from '../../..'
+import { string, trimmed } from '../../../src'
 
 export const Struct = trimmed(string())
 

--- a/test/validation/trimmed/valid.ts
+++ b/test/validation/trimmed/valid.ts
@@ -1,4 +1,4 @@
-import { string, trimmed } from '../../..'
+import { string, trimmed } from '../../../src'
 
 export const Struct = trimmed(string())
 

--- a/test/validation/tuple/invalid-element-missing.ts
+++ b/test/validation/tuple/invalid-element-missing.ts
@@ -1,4 +1,4 @@
-import { tuple, string, number } from '../../..'
+import { tuple, string, number } from '../../../src'
 
 export const Struct = tuple([string(), number()])
 

--- a/test/validation/tuple/invalid-element-unknown.ts
+++ b/test/validation/tuple/invalid-element-unknown.ts
@@ -1,4 +1,4 @@
-import { tuple, string, number } from '../../..'
+import { tuple, string, number } from '../../../src'
 
 export const Struct = tuple([string(), number()])
 

--- a/test/validation/tuple/invalid-element.ts
+++ b/test/validation/tuple/invalid-element.ts
@@ -1,4 +1,4 @@
-import { tuple, string, number } from '../../..'
+import { tuple, string, number } from '../../../src'
 
 export const Struct = tuple([string(), number()])
 

--- a/test/validation/tuple/invalid.ts
+++ b/test/validation/tuple/invalid.ts
@@ -1,4 +1,4 @@
-import { tuple, string, number } from '../../..'
+import { tuple, string, number } from '../../../src'
 
 export const Struct = tuple([string(), number()])
 

--- a/test/validation/tuple/valid.ts
+++ b/test/validation/tuple/valid.ts
@@ -1,4 +1,4 @@
-import { tuple, string, number } from '../../..'
+import { tuple, string, number } from '../../../src'
 
 export const Struct = tuple([string(), number()])
 

--- a/test/validation/type/invalid-property-nested.ts
+++ b/test/validation/type/invalid-property-nested.ts
@@ -1,4 +1,4 @@
-import { type, string, number } from '../../..'
+import { type, string, number } from '../../../src'
 
 export const Struct = type({
   id: number(),

--- a/test/validation/type/invalid-property.ts
+++ b/test/validation/type/invalid-property.ts
@@ -1,4 +1,4 @@
-import { type, string, number } from '../../..'
+import { type, string, number } from '../../../src'
 
 export const Struct = type({
   name: string(),

--- a/test/validation/type/invalid.ts
+++ b/test/validation/type/invalid.ts
@@ -1,4 +1,4 @@
-import { type, string, number } from '../../..'
+import { type, string, number } from '../../../src'
 
 export const Struct = type({
   name: string(),

--- a/test/validation/type/valid-instance.ts
+++ b/test/validation/type/valid-instance.ts
@@ -1,4 +1,4 @@
-import { type, string } from '../../..'
+import { type, string } from '../../../src'
 
 class Person {
   name: string

--- a/test/validation/type/valid.ts
+++ b/test/validation/type/valid.ts
@@ -1,4 +1,4 @@
-import { type, string, number } from '../../..'
+import { type, string, number } from '../../../src'
 
 export const Struct = type({
   name: string(),

--- a/test/validation/union/coercion-nested.ts
+++ b/test/validation/union/coercion-nested.ts
@@ -1,4 +1,4 @@
-import { union, string, number, defaulted, type } from '../../..'
+import { union, string, number, defaulted, type } from '../../../src'
 
 const A = string()
 const B = type({ a: number(), b: defaulted(number(), 5) })

--- a/test/validation/union/coercion.ts
+++ b/test/validation/union/coercion.ts
@@ -1,4 +1,4 @@
-import { union, string, number, defaulted } from '../../..'
+import { union, string, number, defaulted } from '../../../src'
 
 const A = defaulted(string(), 'foo')
 const B = number()

--- a/test/validation/union/invalid.ts
+++ b/test/validation/union/invalid.ts
@@ -1,4 +1,4 @@
-import { type, union, string, number } from '../../..'
+import { type, union, string, number } from '../../../src'
 
 const A = type({ a: string() })
 const B = type({ b: number() })

--- a/test/validation/union/valid.ts
+++ b/test/validation/union/valid.ts
@@ -1,4 +1,4 @@
-import { type, union, string, number } from '../../..'
+import { type, union, string, number } from '../../../src'
 
 const A = type({ a: string() })
 const B = type({ b: number() })

--- a/test/validation/unknown/valid-number.ts
+++ b/test/validation/unknown/valid-number.ts
@@ -1,4 +1,4 @@
-import { unknown } from '../../..'
+import { unknown } from '../../../src'
 
 export const Struct = unknown()
 

--- a/test/validation/unknown/valid-string.ts
+++ b/test/validation/unknown/valid-string.ts
@@ -1,4 +1,4 @@
-import { unknown } from '../../..'
+import { unknown } from '../../../src'
 
 export const Struct = unknown()
 

--- a/test/validation/unknown/valid-undefined.ts
+++ b/test/validation/unknown/valid-undefined.ts
@@ -1,4 +1,4 @@
-import { unknown } from '../../..'
+import { unknown } from '../../../src'
 
 export const Struct = unknown()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,13 @@
   dependencies:
     "@babel/highlight" "^7.16.7"
 
+"@babel/code-frame@^7.12.13":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.17.10":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.10.tgz#711dc726a492dfc8be8220028b1b92482362baab"
@@ -300,6 +307,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
@@ -339,6 +351,15 @@
   integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -1045,6 +1066,32 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
+"@jest/expect-utils@^28.1.1":
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-28.1.1.tgz#d84c346025b9f6f3886d02c48a6177e2b0360587"
+  integrity sha512-n/ghlvdhCdMI/hTcnn4qV57kQuV9OTsZzH1TTCVARANKhl6hXJqLKUkwX69ftMGpsbpt96SsDD8n8LD2d9+FRw==
+  dependencies:
+    jest-get-type "^28.0.2"
+
+"@jest/schemas@^28.0.2":
+  version "28.0.2"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.0.2.tgz#08c30df6a8d07eafea0aef9fb222c5e26d72e613"
+  integrity sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==
+  dependencies:
+    "@sinclair/typebox" "^0.23.3"
+
+"@jest/types@^28.1.1":
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.1.tgz#d059bbc80e6da6eda9f081f293299348bd78ee0b"
+  integrity sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==
+  dependencies:
+    "@jest/schemas" "^28.0.2"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz#cf92a983c83466b8c0ce9124fadeaf09f7c66ea9"
@@ -1123,6 +1170,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sinclair/typebox@^0.23.3":
+  version "0.23.5"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
+  integrity sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1172,10 +1224,36 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/expect@^24.3.0":
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/@types/expect/-/expect-24.3.0.tgz#d7cab8b3c10c2d92a0cbb31981feceb81d3486f1"
+  integrity sha512-aq5Z+YFBz5o2b6Sp1jigx5nsmoZMK5Ceurjwy6PZmRv7dEi1jLtkARfvB1ME+OXJUG+7TZUDcv3WoCr/aor6dQ==
+  dependencies:
+    expect "*"
+
 "@types/http-cache-semantics@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
+  integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff"
+  integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@^7.0.7":
   version "7.0.9"
@@ -1204,7 +1282,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/mocha@^9.0.0":
+"@types/mocha@^9.1.1":
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
@@ -1248,10 +1326,27 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
   integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
 
+"@types/stack-utils@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
+  integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
 "@types/ua-parser-js@^0.7.36":
   version "0.7.36"
   resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz#9bd0b47f26b5a3151be21ba4ce9f5fa457c5f190"
   integrity sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==
+
+"@types/yargs-parser@*":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
+  integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
+
+"@types/yargs@^17.0.8":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.10.tgz#591522fce85d8739bca7b8bb90d048e4478d186a"
+  integrity sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^4.33.0":
   version "4.33.0"
@@ -1419,6 +1514,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1445,6 +1545,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -1500,7 +1605,7 @@ array.prototype.flat@^1.2.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.0"
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
@@ -1652,6 +1757,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer-from@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 builtin-modules@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
@@ -1793,6 +1903,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^3.2.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
+  integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -1955,7 +2070,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2075,10 +2197,20 @@ del@^6.0.0:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
+diff-sequences@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
+  integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
+
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2220,6 +2352,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 eslint-config-prettier@^7.2.0:
   version "7.2.0"
@@ -2411,6 +2548,17 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+expect@*:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-28.1.1.tgz#ca6fff65f6517cf7220c2e805a49c19aea30b420"
+  integrity sha512-/AANEwGL0tWBwzLNOvO0yUdy2D52jVdNXppOqswC49sxMN2cPWsGCQdzuIf9tj6hHoBQzNvx75JUYuQAckPo3w==
+  dependencies:
+    "@jest/expect-utils" "^28.1.1"
+    jest-get-type "^28.0.2"
+    jest-matcher-utils "^28.1.1"
+    jest-message-util "^28.1.1"
+    jest-util "^28.1.1"
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -2733,6 +2881,11 @@ graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -3256,6 +3409,58 @@ issue-regex@^3.1.0:
   resolved "https://registry.yarnpkg.com/issue-regex/-/issue-regex-3.1.0.tgz#0671f094d6449c5b712fac3c9562aecb727d709e"
   integrity sha512-0RHjbtw9QXeSYnIEY5Yrp2QZrdtz21xBDV9C/GIlY2POmgoS6a7qjkYS5siRKXScnuAj5/SPv1C3YForNCHTJA==
 
+jest-diff@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-28.1.1.tgz#1a3eedfd81ae79810931c63a1d0f201b9120106c"
+  integrity sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^28.1.1"
+    jest-get-type "^28.0.2"
+    pretty-format "^28.1.1"
+
+jest-get-type@^28.0.2:
+  version "28.0.2"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
+  integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
+
+jest-matcher-utils@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz#a7c4653c2b782ec96796eb3088060720f1e29304"
+  integrity sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^28.1.1"
+    jest-get-type "^28.0.2"
+    pretty-format "^28.1.1"
+
+jest-message-util@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-28.1.1.tgz#60aa0b475cfc08c8a9363ed2fb9108514dd9ab89"
+  integrity sha512-xoDOOT66fLfmTRiqkoLIU7v42mal/SqwDKvfmfiWAdJMSJiU+ozgluO7KbvoAgiwIrrGZsV7viETjc8GNrA/IQ==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^28.1.1"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^28.1.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-util@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.1.tgz#ff39e436a1aca397c0ab998db5a51ae2b7080d05"
+  integrity sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==
+  dependencies:
+    "@jest/types" "^28.1.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-worker@^26.2.1:
   version "26.6.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.1.tgz#c2ae8cde6802cc14056043f997469ec170d9c32a"
@@ -3563,6 +3768,11 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 map-age-cleaner@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
@@ -3680,6 +3890,13 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+mkdirp@^0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 mocha@^10.0.0:
   version "10.0.0"
@@ -4232,6 +4449,16 @@ prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
+pretty-format@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.1.tgz#f731530394e0f7fcd95aba6b43c50e02d86b95cb"
+  integrity sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==
+  dependencies:
+    "@jest/schemas" "^28.0.2"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -4283,6 +4510,11 @@ rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -4695,6 +4927,14 @@ source-map-support@^0.5.16, source-map-support@~0.5.19:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@^0.5.6:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -4739,6 +4979,13 @@ split@^1.0.1:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+stack-utils@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
+  integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
+  dependencies:
+    escape-string-regexp "^2.0.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -4978,7 +5225,30 @@ ts-clone-node@^1.0.0:
   dependencies:
     compatfactory "^1.0.1"
 
-tsconfig-paths@^3.14.1:
+ts-mocha@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/ts-mocha/-/ts-mocha-10.0.0.tgz#41a8d099ac90dbbc64b06976c5025ffaebc53cb9"
+  integrity sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==
+  dependencies:
+    ts-node "7.0.1"
+  optionalDependencies:
+    tsconfig-paths "^3.5.0"
+
+ts-node@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
+  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+  dependencies:
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
+
+tsconfig-paths@^3.14.1, tsconfig-paths@^3.5.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
   integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
@@ -5281,3 +5551,8 @@ yargs@16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
+  integrity sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==


### PR DESCRIPTION
Fixes #1085. Read more about the problem statement there.

#### Summary of changes:

* Tests now run against the raw Typescript source. This was necessary because Mocha is awful and renaming the `cjs` bundle caused the entire test system to fall apart. The one I put in place is faster, and unlocks watch mode (`yarn test --watch`)
* Renamed CommonJS bundle to `cjs.js`