### PR TITLE
Stop coercing empty optional fields to undefined values

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,7 +175,7 @@ export function* run<T, S>(
         } else if (value instanceof Set) {
           value.add(v)
         } else if (isObject(value)) {
-          value[k] = v
+          if (v !== undefined) value[k] = v
         }
       }
     }

--- a/test/api/create.ts
+++ b/test/api/create.ts
@@ -1,5 +1,5 @@
-import { strictEqual } from 'assert'
-import { create, string, defaulted } from '../..'
+import { strictEqual, deepEqual } from 'assert'
+import { type, optional, create, string, defaulted } from '../..'
 
 describe('create', () => {
   it('missing as helper', () => {
@@ -20,5 +20,14 @@ describe('create', () => {
   it('not missing as method', () => {
     const S = defaulted(string(), 'default')
     strictEqual(S.create('string'), 'string')
+  })
+
+  it('optional fields not undefined', () => {
+    const S = type({
+      a: string(),
+      b: optional(string()),
+      c: optional(type({ d: string() })),
+    })
+    deepEqual(S.create({ a: 'a' }), { a: 'a' })
   })
 })


### PR DESCRIPTION
While using create to coerce some data, optional fields are defined to undefined values.
This causes problems when storing the result directly in MongoDB (generates null values).
The PR removes these undefined fields from the result of the create call.

Fix for #981 