### PR TITLE
Support Node 14 (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,14 @@ on: [push, pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
       - run: yarn && yarn test && yarn lint
         env:
           CI: true

--- a/config/rollup.js
+++ b/config/rollup.js
@@ -23,7 +23,7 @@ export default {
         [
           '@babel/preset-env',
           {
-            targets: { browsers: 'defaults, not ie 11', node: true },
+            targets: { browsers: 'defaults, not ie 11', node: '14.0' },
             modules: false,
             useBuiltIns: false,
             loose: true,

--- a/package.json
+++ b/package.json
@@ -107,5 +107,8 @@
     "validation",
     "validator"
   ],
-  "dependencies": {}
+  "dependencies": {},
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }


### PR DESCRIPTION
It appears that between 0.16.0 and 0.16.1, the minimum version of Node required to use this package changed, from 14.x to 16.x. This was not explicit but seems to have been caused by a couple of factors.

But first, what changed. If you look at `src/error.ts` in 0.16.0 you will see [this line][1]:

```
return (cached ??= [failure, ...failures()])
```

In the [published version of this file in 0.16.0][2] this gets transpiled to:

```
return (_cached = cached) != null ? _cached : cached = [failure, ...failures()];
```

In 0.16.1, the [original line is unchanged][3], but in the [published version][4] it is transpiled to:

```
return cached ??= [failure, ...failures()];
```

The `??=` syntax is not supported by Node 14, hence, developers are forced to upgrade to at least Node 16 if they want to use v0.16.1 or greater.

After looking at the diff between these two versions and running some experiments, I believe that there are two reasons why this line shows up differently in these two published versions.

1. Different Node versions were used to build and publish these versions. It appears that Node 14 was used for the former whereas Node 16 was used for the latter. This assertion is supported by the fact that in the [Rollup configuration][5], `@babel/preset-env` is configured with `node: true`, which instructs Babel to [use the current version of Node as a target][6]. So if the current Node version changes, so does the Babel config.
2. Between 0.16.0 and 0.16.1, [`browserslist` was updated from 4.20.3, to 4.21.4][7] (you will probably need to expand `yarn.lock`; if so, Cmd-F for "browserslist"). In `browserslist` 4.21.0, [IE 11 was removed from the default set of browsers][8] (which is being used in this case, since no explicit list is provided). According to caniuse, [IE 11 does not support the `??=` syntax][9], so its removal means that Babel doesn't need to transpile this syntax any longer.

To address this problem, this PR:

* changes the Rollup configuration mentioned above to use `node: "14.0"` instead of `node: true`, so that Node 14 is always used to compute the transpilation rules regardless of the version of Node used locally to build and publish the package
* updates the CI workflow to ensure that Node 14 is being tested (along with 16 and 18)
* adds Node >= 14 to the `engines` field to communicate that it is supported

---

One thing you may wonder is why this change is needed at all. Node 16 is the current LTS, so shouldn't that be enough? True, but Node 14 hasn't hit end-of-life yet, and many people are still using it, including my company. We think this package is really great, but it would be even better if we didn't have to have a workaround for our libraries that we still want to keep on Node 14.

Thanks for considering :)

[1]: https://github.com/ianstormtaylor/superstruct/blob/v0.16.0/src/error.ts#L44
[2]: https://unpkg.com/superstruct@0.16.0/lib/index.cjs
[3]: https://github.com/ianstormtaylor/superstruct/blob/v0.16.1/src/error.ts#L44
[4]: https://unpkg.com/superstruct@0.16.1/lib/index.cjs.js
[5]: https://github.com/ianstormtaylor/superstruct/blob/v0.16.4/config/rollup.js#L26
[6]: https://babel.dev/docs/en/options#targetsnode
[7]: https://github.com/ianstormtaylor/superstruct/compare/v0.16.0...v0.16.1?diff=unified#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deL99
[8]: https://github.com/browserslist/browserslist/blob/main/CHANGELOG.md#421
[9]: https://caniuse.com/?search=%3F%3F%3D