### PR TITLE
Allow optional and nullable enums

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -213,7 +213,7 @@ export type Assign<T, U> = Simplify<U & Omit<T, keyof U>>
  * A schema for enum structs.
  */
 
-export type EnumSchema<T extends string | number | undefined> = {
+export type EnumSchema<T extends string | number | undefined | null> = {
   [K in NonNullable<T>]: K
 }
 
@@ -330,14 +330,14 @@ export type If<B extends Boolean, Then, Else> = B extends true ? Then : Else
  * A schema for any type of struct.
  */
 
-export type StructSchema<T> = [T] extends [string | undefined]
-  ? [T] extends [IsMatch<T, string | undefined>]
+export type StructSchema<T> = [T] extends [string | undefined | null]
+  ? [T] extends [IsMatch<T, string | undefined | null>]
     ? null
     : [T] extends [IsUnion<T>]
     ? EnumSchema<T>
     : T
-  : [T] extends [number | undefined]
-  ? [T] extends [IsMatch<T, number | undefined>]
+  : [T] extends [number | undefined | null]
+  ? [T] extends [IsMatch<T, number | undefined | null>]
     ? null
     : [T] extends [IsUnion<T>]
     ? EnumSchema<T>


### PR DESCRIPTION
I'd like to add `nullable` in [this](https://github.com/ianstormtaylor/superstruct/pull/694) case.

I couldn't find any problems with following:

```bash
yarn test
```

and

```ts
const undefinedTestTypeSchema: Describe<undefined> = literal(undefined)

const nullTestTypeSchema: Describe<null> = literal(null)

const optionalTestTypeSchema: Describe<string | undefined> = optional(string())

const partialEnumTypeSchema: Describe<{ foo?: 'bar' | 'baz' }> = object({
  foo: optional(enums(['bar', 'baz'] as const)),
})

const partialAndNullableEnumTypeSchema: Describe<{
  foo?: 'bar' | 'baz' | null
}> = object({
  foo: optional(nullable(enums(['bar', 'baz'] as const))),
})

const nullableEnumTypeSchema: Describe<{
  foo: 'bar' | 'baz' | null
}> = object({
  foo: nullable(enums(['bar', 'baz'] as const)),
})

const optionalUndefinedSchema: Describe<{ foo?: undefined }> = object({
  foo: literal(undefined),
})

const optionalNullSchema: Describe<{ foo?: null }> = object({
  foo: optional(literal(null)),
})
```