### PR TITLE
nicer error message for union mismatches

### DIFF
--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -522,10 +522,15 @@ export function union<A extends AnyStruct, B extends AnyStruct[]>(
         }
       }
 
+      const hint = failures.find((failure) => failure.path)
+      const hintMessage = hint
+        ? `\n\tAt key \`${hint.path}\` -- ${hint.message}`
+        : ''
+
       return [
         `Expected the value to satisfy a union of \`${description}\`, but received: ${print(
           value
-        )}`,
+        )}${hintMessage}`,
         ...failures,
       ]
     },


### PR DESCRIPTION
See issue #831 for details.

I'd be grateful if this PR could count against Hacktoberfest 🎃 (using the 'hacktoberfest-accepted' label) but of course there is no obligation!