### PR TITLE
Fix Symbol serialisation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,10 @@ export function isPlainObject(x: unknown): x is { [key: string]: any } {
  */
 
 export function print(value: any): string {
+  if (typeof value === 'symbol') {
+    return value.toString()
+  }
+
   return typeof value === 'string' ? JSON.stringify(value) : `${value}`
 }
 


### PR DESCRIPTION
Fixes #1134.

Doing \`${Symbol('foo')}\` results in "TypeError: Cannot convert a Symbol value to a string". Using `Symbol('foo').toString()` works however, and results in the string `"Symbol(foo)"`.