### PR TITLE
Document the usage of the type struct in the omit utility

### DIFF
--- a/docs/reference/utilities.md
+++ b/docs/reference/utilities.md
@@ -73,7 +73,7 @@ omit(
 )
 ```
 
-`omit` allows you to create a new struct based on an existing object struct, but excluding specific properties.
+`omit` allows you to create a new struct based on an existing `object` or `type` struct, but excluding specific properties.
 
 ### `partial`
 


### PR DESCRIPTION
Noticed that `omit` is missing the mention of `type` whilst writing #1149.