### PR TITLE
Allow frozen objects/arrays to be coerced

### DIFF
--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -476,6 +476,9 @@ export function tuple<A extends AnyStruct, B extends AnyStruct[]>(
         `Expected an array, but received: ${print(value)}`
       )
     },
+    coercer(value) {
+      return Array.isArray(value) ? value.slice() : value
+    },
   })
 }
 

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -387,7 +387,7 @@ export function record<K extends string, V>(
       )
     },
     coercer(value) {
-      return isObject(value) ? { ...value } : value
+      return isNonArrayObject(value) ? { ...value } : value
     },
   })
 }

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -386,6 +386,9 @@ export function record<K extends string, V>(
         `Expected an object, but received: ${print(value)}`
       )
     },
+    coercer(value) {
+      return isObject(value) ? { ...value } : value
+    },
   })
 }
 

--- a/test/validation/array/valid-frozen.ts
+++ b/test/validation/array/valid-frozen.ts
@@ -1,0 +1,9 @@
+import { array, number } from '../../../src'
+
+export const Struct = array(number())
+
+export const data = Object.freeze([1, 2, 3])
+
+export const output = [1, 2, 3]
+
+export const create = true

--- a/test/validation/object/valid-frozen.ts
+++ b/test/validation/object/valid-frozen.ts
@@ -1,0 +1,18 @@
+import { object, string, number } from '../../../src'
+
+export const Struct = object({
+  name: string(),
+  age: number(),
+})
+
+export const data = Object.freeze({
+  name: 'john',
+  age: 42,
+})
+
+export const output = {
+  name: 'john',
+  age: 42,
+}
+
+export const create = true

--- a/test/validation/record/valid-frozen.ts
+++ b/test/validation/record/valid-frozen.ts
@@ -1,0 +1,15 @@
+import { record, string, number } from '../../../src'
+
+export const Struct = record(string(), number())
+
+export const data = Object.freeze({
+  a: 1,
+  b: 2,
+})
+
+export const output = {
+  a: 1,
+  b: 2,
+}
+
+export const create = true

--- a/test/validation/tuple/valid-frozen.ts
+++ b/test/validation/tuple/valid-frozen.ts
@@ -1,0 +1,9 @@
+import { tuple, string, number } from '../../../src'
+
+export const Struct = tuple([string(), number()])
+
+export const data = Object.freeze(['A', 1])
+
+export const output = ['A', 1]
+
+export const create = true

--- a/test/validation/type/valid-frozen.ts
+++ b/test/validation/type/valid-frozen.ts
@@ -1,0 +1,18 @@
+import { type, string, number } from '../../../src'
+
+export const Struct = type({
+  name: string(),
+  age: number(),
+})
+
+export const data = Object.freeze({
+  name: 'john',
+  age: 42,
+})
+
+export const output = {
+  name: 'john',
+  age: 42,
+}
+
+export const create = true


### PR DESCRIPTION
## The Bug

The issue was the [mutation of the input object/array](https://github.com/ianstormtaylor/superstruct/blob/03d65bd37d505d934db7cb48eed691fc41ecba7c/src/utils.ts#L185) while coercing entries inside the `run` util -- combined with a missing custom coercer which would clone its input (exactly as @gwisp2 suggested in #1096).

Apart from `record`, `tuple` was also affected by the same potential issue.

## PR Changes

1. Added coercer that clones its input to `record` and `tuple`.
1. Added tests with frozen objects for all structs which _could_ potentially be affected (object/array based and include entries).

---

Resolves #1096