### PR TITLE
Show object properties and values in failure message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,11 +72,12 @@ export function toFailure<T, S>(
 
   const { path, branch } = context
   const { type } = struct
+  const finalValue = typeof value === 'object' ? JSON.stringify(value) : value
   const {
     refinement,
     message = `Expected a value of type \`${type}\`${
       refinement ? ` with refinement \`${refinement}\`` : ''
-    }, but received: \`${print(value)}\``,
+    }, but received: \`${print(finalValue)}\``,
   } = result
 
   return {


### PR DESCRIPTION
This will help for debugging when the assert has failed.

When a value is an object, the message for failure contains [object Object].

Adding a stringify on the value if its type is object seems like the quickiest win for easier debugging.