### PR TITLE
make more of the examples runnable

### DIFF
--- a/docs/guides/02-validating-data.md
+++ b/docs/guides/02-validating-data.md
@@ -39,12 +39,7 @@ Here we're ensuring that `data` is a valid `Date` object.
 In addition to simple, "flat" values, you can also compose structs into more complex shapes. The most common example of this is `object` structs:
 
 ```ts
-import {
-  assert,
-  number,
-  object,
-  string,
-} from 'superstruct'
+import { assert, number, object, string } from 'superstruct'
 
 const User = object({
   id: number(),
@@ -87,11 +82,7 @@ This `User` struct will ensure that input data is an object with specific shape 
 You could also define a struct which represents a list of values that all match a specific type, using the `array` factory. For example:
 
 ```ts
-import {
-  array,
-  assert,
-  number,
-} from 'superstruct'
+import { array, assert, number } from 'superstruct'
 
 const Struct = array(number())
 
@@ -125,12 +116,7 @@ const Team = object({
 You can also model optional properties. For example, maybe an `email` address isn't strictly required for all your users, you could do:
 
 ```ts
-import {
-  number,
-  object,
-  optional,
-  string,
-} from 'superstruct'
+import { number, object, optional, string } from 'superstruct'
 
 const User = object({
   id: number(),

--- a/docs/guides/02-validating-data.md
+++ b/docs/guides/02-validating-data.md
@@ -7,7 +7,7 @@ Superstruct is designed to let you validate any data, ensuring that it matches a
 The simplest structs are ones that validate "primitive" values, like strings, numbers or booleans. For example:
 
 ```ts
-import { string } from 'superstruct'
+import { assert, string } from 'superstruct'
 
 const Struct = string()
 
@@ -22,7 +22,7 @@ In this case, `assert` will throw an error if the input `data` is not a a string
 But Superstruct has simple structs like these for more than the primitive types. It has support out of the box for many of the common types you might need to validate—dates, functions, regexps, etc.
 
 ```ts
-import { date } from 'superstruct'
+import { assert, date } from 'superstruct'
 
 const Struct = date()
 
@@ -39,6 +39,13 @@ Here we're ensuring that `data` is a valid `Date` object.
 In addition to simple, "flat" values, you can also compose structs into more complex shapes. The most common example of this is `object` structs:
 
 ```ts
+import {
+  assert,
+  number,
+  object,
+  string,
+} from 'superstruct'
+
 const User = object({
   id: number(),
   email: string(),
@@ -80,7 +87,11 @@ This `User` struct will ensure that input data is an object with specific shape 
 You could also define a struct which represents a list of values that all match a specific type, using the `array` factory. For example:
 
 ```ts
-import { array } from 'superstruct'
+import {
+  array,
+  assert,
+  number,
+} from 'superstruct'
 
 const Struct = array(number())
 
@@ -114,7 +125,12 @@ const Team = object({
 You can also model optional properties. For example, maybe an `email` address isn't strictly required for all your users, you could do:
 
 ```ts
-import { optional } from 'superstruct'
+import {
+  number,
+  object,
+  optional,
+  string,
+} from 'superstruct'
 
 const User = object({
   id: number(),

--- a/docs/guides/03-coercing-data.md
+++ b/docs/guides/03-coercing-data.md
@@ -9,7 +9,13 @@ To allow for these use cases, Superstruct has a concept called "coercion", which
 Since defaults are such a common case, Superstruct comes with a `defaulted` helper that makes defining default values easy:
 
 ```ts
-import { defaulted, create } from 'superstruct'
+import {
+  create,
+  defaulted,
+  number,
+  object,
+  string,
+} from 'superstruct'
 
 let i = 0
 

--- a/docs/guides/03-coercing-data.md
+++ b/docs/guides/03-coercing-data.md
@@ -9,13 +9,7 @@ To allow for these use cases, Superstruct has a concept called "coercion", which
 Since defaults are such a common case, Superstruct comes with a `defaulted` helper that makes defining default values easy:
 
 ```ts
-import {
-  create,
-  defaulted,
-  number,
-  object,
-  string,
-} from 'superstruct'
+import { create, defaulted, number, object, string } from 'superstruct'
 
 let i = 0
 

--- a/docs/guides/04-refining-validation.md
+++ b/docs/guides/04-refining-validation.md
@@ -9,7 +9,7 @@ For these situations, you can use "refinements". Refinements allow you to create
 Superstruct has several [built-in refinements](../reference/refinements.md) for common use cases. For example, a common one is ensuring that a string matches a specific regular expression pattern:
 
 ```ts
-import { pattern } from 'superstruct'
+import { assert, pattern, string } from 'superstruct'
 
 const Section = pattern(string(), /\d+(\.\d+/)?/)
 
@@ -21,7 +21,7 @@ assert('string', Section) // throws!
 Or maybe that a string (or array, number, etc.) has a specific size:
 
 ```ts
-import { size } from 'superstruct'
+import { assert, size, string } from 'superstruct'
 
 const Name = size(string(), 1, 100)
 
@@ -32,7 +32,7 @@ assert('', Name) // throws!
 Another common use case is validating nonnegative integers (like indexes in an array) using the built-in `min` helper:
 
 ```ts
-import { min, integer } from 'superstruct'
+import { assert, min, integer } from 'superstruct'
 
 const Index = min(integer(), 0)
 
@@ -49,7 +49,7 @@ These refinements don't change the inferred type of the data, but they do ensure
 You can also write your own custom refinements for more domain-specific use cases. For example, for a specific kind of string:
 
 ```ts
-import { refine } from 'superstruct'
+import { refine, string } from 'superstruct'
 
 const MyString = refine(string(), 'MyString', (value) => {
   return value.startsWith('The') && value.length > 20

--- a/docs/guides/06-using-typescript.md
+++ b/docs/guides/06-using-typescript.md
@@ -9,9 +9,16 @@ Superstruct is built with TypeScript, and is designed to integrate seamlessly wi
 Whenever you use the `is` or `assert` helpers in Superstruct, TypeScript will infer information about your data and give you type safety. For example:
 
 ```ts
+import {
+  is,
+  number,
+  object,
+  string,
+} from 'superstruct'
+
 const User = object({
   id: number(),
-  email: email(),
+  email: string(),
   name: string(),
 })
 
@@ -55,11 +62,16 @@ In this case, the incorrectly defined `id` property will cause TypeScript's comp
 You can also do the reverse and infer a TypeScript type using an existing Superstruct struct with the `Infer` utility. For example:
 
 ```ts
-import { Infer } from 'superstruct'
+import {
+  Infer,
+  number,
+  object,
+  string,
+} from 'superstruct'
 
 const User = object({
   id: number(),
-  email: email(),
+  email: string(),
   name: string(),
 })
 

--- a/docs/guides/06-using-typescript.md
+++ b/docs/guides/06-using-typescript.md
@@ -9,12 +9,7 @@ Superstruct is built with TypeScript, and is designed to integrate seamlessly wi
 Whenever you use the `is` or `assert` helpers in Superstruct, TypeScript will infer information about your data and give you type safety. For example:
 
 ```ts
-import {
-  is,
-  number,
-  object,
-  string,
-} from 'superstruct'
+import { is, number, object, string } from 'superstruct'
 
 const User = object({
   id: number(),
@@ -62,12 +57,7 @@ In this case, the incorrectly defined `id` property will cause TypeScript's comp
 You can also do the reverse and infer a TypeScript type using an existing Superstruct struct with the `Infer` utility. For example:
 
 ```ts
-import {
-  Infer,
-  number,
-  object,
-  string,
-} from 'superstruct'
+import { Infer, number, object, string } from 'superstruct'
 
 const User = object({
   id: number(),


### PR DESCRIPTION
Many of the examples in the docs have some imports but not all. That was confusing for me, especially because `assert` exists in std lib of Node.js.

This PR doesn't thrive do make all examples copy-pasteable, only the ones that already had import declarations by making the list of imports complete.