### PR TITLE
Fixes #1192 - extends abstract (and non-abstract) class

### DIFF
--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -140,7 +140,7 @@ export function func(): Struct<Function, null> {
  * Ensure that a value is an instance of a specific class.
  */
 
-export function instance<T extends { new (...args: any): any }>(
+export function instance<T extends abstract new (...args: any) => any>(
   Class: T
 ): Struct<InstanceType<T>, null> {
   return define('instance', (value) => {


### PR DESCRIPTION
I tested this as a PNPM patch, and it seemed to work locally. It's the same syntax `InstanceType` uses.

I think, in TypeScript terms, `new () => any` is a subtype of `abstract new () => any`, so this ends up covering both cases.