### PR TITLE
Fix mask() working incorrectly with union() when an alternative object contains extra unknown props

### DIFF
--- a/src/struct.ts
+++ b/src/struct.ts
@@ -86,7 +86,8 @@ export class Struct<T = unknown, S = unknown> {
 
   /**
    * Mask a value, coercing and validating it, but returning only the subset of
-   * properties defined by the struct's schema.
+   * properties defined by the struct's schema. Masking applies recursively to
+   * props of `object` structs only.
    */
 
   mask(value: unknown, message?: string): T {
@@ -97,15 +98,17 @@ export class Struct<T = unknown, S = unknown> {
    * Validate a value with the struct's validation logic, returning a tuple
    * representing the result.
    *
-   * You may optionally pass `true` for the `withCoercion` argument to coerce
+   * You may optionally pass `true` for the `coerce` argument to coerce
    * the value before attempting to validate it. If you do, the result will
-   * contain the coerced result when successful.
+   * contain the coerced result when successful. Also, `mask` will turn on
+   * masking of the unknown `object` props recursively if passed.
    */
 
   validate(
     value: unknown,
     options: {
       coerce?: boolean
+      mask?: boolean
       message?: string
     } = {}
   ): [StructError, undefined] | [undefined, T] {
@@ -209,12 +212,16 @@ export function validate<T, S>(
 
 /**
  * A `Context` contains information about the current location of the
- * validation inside the initial input value.
+ * validation inside the initial input value. It also carries `mask`
+ * since it's a run-time flag determining how the validation was invoked
+ * (via `mask()` or via `validate()`), plus it applies recursively
+ * to all of the nested structs.
  */
 
 export type Context = {
   branch: Array<any>
   path: Array<any>
+  mask?: boolean
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,24 +131,10 @@ export function* run<T, S>(
   } = {}
 ): IterableIterator<[Failure, undefined] | [undefined, T]> {
   const { path = [], branch = [value], coerce = false, mask = false } = options
-  const ctx: Context = { path, branch }
+  const ctx: Context = { path, branch, mask }
 
   if (coerce) {
     value = struct.coercer(value, ctx)
-
-    if (
-      mask &&
-      struct.type !== 'type' &&
-      isObject(struct.schema) &&
-      isObject(value) &&
-      !Array.isArray(value)
-    ) {
-      for (const key in value) {
-        if (struct.schema[key] === undefined) {
-          delete value[key]
-        }
-      }
-    }
   }
 
   let status: 'valid' | 'not_refined' | 'not_valid' = 'valid'

--- a/test/api/mask.ts
+++ b/test/api/mask.ts
@@ -7,6 +7,7 @@ import {
   StructError,
   array,
   type,
+  union,
 } from '../../src'
 
 describe('mask', () => {
@@ -46,17 +47,34 @@ describe('mask', () => {
   it('masking of a nested type', () => {
     const S = object({
       id: string(),
-      sub: array(type({ prop: string() })),
+      sub: array(
+        type({ prop: string(), defaultedProp: defaulted(string(), '42') })
+      ),
+      union: array(union([object({ prop: string() }), type({ k: string() })])),
     })
     const value = {
       id: '1',
       unknown: true,
       sub: [{ prop: '2', unknown: true }],
+      union: [
+        { prop: '3', unknown: true },
+        { k: '4', unknown: true },
+      ],
     }
     deepStrictEqual(mask(value, S), {
       id: '1',
-      sub: [{ prop: '2', unknown: true }],
+      sub: [{ prop: '2', unknown: true, defaultedProp: '42' }],
+      union: [{ prop: '3' }, { k: '4', unknown: true }],
     })
+  })
+
+  it('masking succeeds for objects with extra props in union', () => {
+    const S = union([
+      object({ a: string(), defaultedProp: defaulted(string(), '42') }),
+      object({ b: string() }),
+    ])
+    const value = { a: '1', extraProp: 42 }
+    deepStrictEqual(mask(value, S), { a: '1', defaultedProp: '42' })
   })
 
   it('masking of a top level type and nested object', () => {


### PR DESCRIPTION
Fixes https://github.com/ianstormtaylor/superstruct/issues/803

Basically, it's a more proper rework of my previous PR https://github.com/ianstormtaylor/superstruct/pull/629 merged several year ago. The fact is that "mask" approach applies to `object` structs only, so it's more proper even conceptually to put the masking logic into object() constructor rather than having it in run(). By doing so, I also fix a bug where union() did not work properly with mask(): before, instead of removing the unknown props when a union element matches, it mistakenly threw a "Expected the value to satisfy a union" error.

## Test plan

```
npm run test
```

Before, the added test threw:

<img width="890" alt="CleanShot 2023-11-28 at 18 39 03@2x" src="https://github.com/ianstormtaylor/superstruct/assets/65643/3ab4298c-4ca7-4121-88b9-b61edc27c8e9">

After, all the tests (including the new ones) pass.
