### PR TITLE
Added code to enable type printing

### DIFF
--- a/src/struct.ts
+++ b/src/struct.ts
@@ -33,13 +33,14 @@ export class Struct<T = unknown, S = unknown> {
       type,
       schema,
       validator,
+      extend,
       refiner,
       coercer = (value: unknown) => value,
       entries = function* () {},
     } = props
 
     this.type = type
-    this.extend = props.extend;
+    this.extend = extend
     this.schema = schema
     this.entries = entries
     this.coercer = coercer

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -11,6 +11,7 @@ export class Struct<T = unknown, S = unknown> {
   readonly TYPE!: T
   type: string
   schema: S
+  extend?: any
   coercer: (value: unknown, context: Context) => unknown
   validator: (value: unknown, context: Context) => Iterable<Failure>
   refiner: (value: T, context: Context) => Iterable<Failure>
@@ -22,6 +23,7 @@ export class Struct<T = unknown, S = unknown> {
   constructor(props: {
     type: string
     schema: S
+    extend?: any
     coercer?: Coercer
     validator?: Validator
     refiner?: Refiner<T>
@@ -37,6 +39,7 @@ export class Struct<T = unknown, S = unknown> {
     } = props
 
     this.type = type
+    this.extend = props.extend;
     this.schema = schema
     this.entries = entries
     this.coercer = coercer

--- a/src/structs/coercions.ts
+++ b/src/structs/coercions.ts
@@ -42,7 +42,7 @@ export function defaulted<T, S>(
     strict?: boolean
   } = {}
 ): Struct<T, S> {
-  return coerce(struct, unknown(), (x) => {
+  const result = coerce(struct, unknown(), (x) => {
     const f = typeof fallback === 'function' ? fallback() : fallback
 
     if (x === undefined) {
@@ -67,6 +67,10 @@ export function defaulted<T, S>(
 
     return x
   })
+
+  result.extend = ["def", fallback];
+
+  return result;
 }
 
 /**

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -143,16 +143,16 @@ export function func(): Struct<Function, null> {
 export function instance<T extends { new (...args: any): any }>(
   Class: T
 ): Struct<InstanceType<T>, T> {
-  return new Struct({ 
-    type: 'instance', 
-    schema: Class, 
+  return new Struct({
+    type: 'instance',
+    schema: Class,
     validator: (value) => {
       return (
         value instanceof Class ||
         `Expected a \`${Class.name}\` instance, but received: ${print(value)}`
       )
     }
-  });
+  })
 }
 
 /**
@@ -229,7 +229,7 @@ export function map(): Struct<Map<unknown, unknown>, null>
 export function map<K, V>(
   Key: Struct<K>,
   Value: Struct<V>
-): Struct<Map<K, V>, [K, V]>
+): Struct<Map<K, V>, [Struct<K>, Struct<V>]>
 export function map<K, V>(Key?: Struct<K>, Value?: Struct<V>): any {
   return new Struct({
     type: 'map',

--- a/src/structs/types.ts
+++ b/src/structs/types.ts
@@ -142,13 +142,17 @@ export function func(): Struct<Function, null> {
 
 export function instance<T extends { new (...args: any): any }>(
   Class: T
-): Struct<InstanceType<T>, null> {
-  return define('instance', (value) => {
-    return (
-      value instanceof Class ||
-      `Expected a \`${Class.name}\` instance, but received: ${print(value)}`
-    )
-  })
+): Struct<InstanceType<T>, T> {
+  return new Struct({ 
+    type: 'instance', 
+    schema: Class, 
+    validator: (value) => {
+      return (
+        value instanceof Class ||
+        `Expected a \`${Class.name}\` instance, but received: ${print(value)}`
+      )
+    }
+  });
 }
 
 /**
@@ -170,10 +174,10 @@ export function integer(): Struct<number, null> {
 
 export function intersection<A extends AnyStruct, B extends AnyStruct[]>(
   Structs: [A, ...B]
-): Struct<Infer<A> & UnionToIntersection<InferStructTuple<B>[number]>, null> {
+): Struct<Infer<A> & UnionToIntersection<InferStructTuple<B>[number]>, [A, ...B]> {
   return new Struct({
     type: 'intersection',
-    schema: null,
+    schema: Structs,
     *entries(value, ctx) {
       for (const S of Structs) {
         yield* S.entries(value, ctx)
@@ -225,11 +229,11 @@ export function map(): Struct<Map<unknown, unknown>, null>
 export function map<K, V>(
   Key: Struct<K>,
   Value: Struct<V>
-): Struct<Map<K, V>, null>
+): Struct<Map<K, V>, [K, V]>
 export function map<K, V>(Key?: Struct<K>, Value?: Struct<V>): any {
   return new Struct({
     type: 'map',
-    schema: null,
+    schema: [Key, Value],
     *entries(value) {
       if (Key && Value && value instanceof Map) {
         for (const [k, v] of value.entries()) {
@@ -265,6 +269,7 @@ export function never(): Struct<never, null> {
 export function nullable<T, S>(struct: Struct<T, S>): Struct<T | null, S> {
   return new Struct({
     ...struct,
+    extend: ["null"],
     validator: (value, ctx) => value === null || struct.validator(value, ctx),
     refiner: (value, ctx) => value === null || struct.refiner(value, ctx),
   })
@@ -332,6 +337,7 @@ export function object<S extends ObjectSchema>(schema?: S): any {
 export function optional<T, S>(struct: Struct<T, S>): Struct<T | undefined, S> {
   return new Struct({
     ...struct,
+    extend: ["?"],
     validator: (value, ctx) =>
       value === undefined || struct.validator(value, ctx),
     refiner: (value, ctx) => value === undefined || struct.refiner(value, ctx),
@@ -348,10 +354,10 @@ export function optional<T, S>(struct: Struct<T, S>): Struct<T | undefined, S> {
 export function record<K extends string, V>(
   Key: Struct<K>,
   Value: Struct<V>
-): Struct<Record<K, V>, null> {
+): Struct<Record<K, V>, [Struct<K>, Struct<V>]> {
   return new Struct({
     type: 'record',
-    schema: null,
+    schema: [Key, Value],
     *entries(value) {
       if (isObject(value)) {
         for (const k in value) {
@@ -388,11 +394,11 @@ export function regexp(): Struct<RegExp, null> {
  */
 
 export function set(): Struct<Set<unknown>, null>
-export function set<T>(Element: Struct<T>): Struct<Set<T>, null>
+export function set<T>(Element: Struct<T>): Struct<Set<T>, Struct<T>>
 export function set<T>(Element?: Struct<T>): any {
   return new Struct({
     type: 'set',
-    schema: null,
+    schema: Element,
     *entries(value) {
       if (Element && value instanceof Set) {
         for (const v of value) {
@@ -432,12 +438,12 @@ export function string(): Struct<string, null> {
 
 export function tuple<A extends AnyStruct, B extends AnyStruct[]>(
   Structs: [A, ...B]
-): Struct<[Infer<A>, ...InferStructTuple<B>], null> {
+): Struct<[Infer<A>, ...InferStructTuple<B>], [A, ...B]> {
   const Never = never()
 
   return new Struct({
     type: 'tuple',
-    schema: null,
+    schema: Structs,
     *entries(value) {
       if (Array.isArray(value)) {
         const length = Math.max(Structs.length, value.length)
@@ -494,11 +500,11 @@ export function type<S extends ObjectSchema>(
 
 export function union<A extends AnyStruct, B extends AnyStruct[]>(
   Structs: [A, ...B]
-): Struct<Infer<A> | InferStructTuple<B>[number], null> {
+): Struct<Infer<A> | InferStructTuple<B>[number], [A, ...B]> {
   const description = Structs.map((s) => s.type).join(' | ')
   return new Struct({
     type: 'union',
-    schema: null,
+    schema: Structs,
     coercer(value) {
       for (const S of Structs) {
         const [error, coerced] = S.validate(value, { coerce: true })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -339,6 +339,7 @@ export type If<B extends Boolean, Then, Else> = B extends true ? Then : Else
  */
 
 export type StructSchema<T> = [T] extends [string | undefined | null]
+
   ? [T] extends [IsMatch<T, string | undefined | null>]
     ? null
     : [T] extends [IsUnion<T>]
@@ -354,18 +355,21 @@ export type StructSchema<T> = [T] extends [string | undefined | null]
   ? [T] extends [IsExactMatch<T, boolean>]
     ? null
     : T
+  : T extends RegExp | Date | Function
+  ? null
+  : T extends Set<infer A>
+  ? Struct<A>
+  : T extends Record<infer A, infer B>
+  ? [Struct<A>, Struct<B>]
+  : T extends Map<infer A, infer B>
+  ? [A, B]
   : T extends
       | bigint
       | symbol
       | undefined
       | null
-      | Function
-      | Date
       | Error
-      | RegExp
-      | Map<any, any>
       | WeakMap<any, any>
-      | Set<any>
       | WeakSet<any>
       | Promise<any>
   ? null

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -339,9 +339,8 @@ export type If<B extends Boolean, Then, Else> = B extends true ? Then : Else
  */
 
 export type StructSchema<T> = [T] extends [string | undefined | null]
-
   ? [T] extends [IsMatch<T, string | undefined | null>]
-    ? null
+    ? any
     : [T] extends [IsUnion<T>]
     ? EnumSchema<T>
     : T
@@ -355,33 +354,32 @@ export type StructSchema<T> = [T] extends [string | undefined | null]
   ? [T] extends [IsExactMatch<T, boolean>]
     ? null
     : T
-  : T extends RegExp | Date | Function
-  ? null
-  : T extends Set<infer A>
-  ? Struct<A>
-  : T extends Record<infer A, infer B>
-  ? [Struct<A>, Struct<B>]
-  : T extends Map<infer A, infer B>
-  ? [A, B]
+  : T extends Map<infer K, infer V>
+  ? [Struct<K>, Struct<V>]
+  : T extends Set<infer V>
+  ? Struct<V>
   : T extends
       | bigint
       | symbol
       | undefined
       | null
+      | Function
+      | Date
       | Error
+      | RegExp
       | WeakMap<any, any>
       | WeakSet<any>
       | Promise<any>
   ? null
   : T extends Array<infer E>
   ? T extends IsTuple<T>
-    ? null
+    ? any
     : Struct<E>
   : T extends object
   ? T extends IsRecord<T>
-    ? null
+    ? [any, any]
     : { [K in keyof T]: Describe<T[K]> }
-  : null
+  : any
 
 /**
  * A schema for tuple structs.


### PR DESCRIPTION
Hello,

I have a use case where I'd like to be able to export a string containing the Typescript types for a given Superstruct.

This kinda works, many of the types have a `schema` property in the `Struct` class that can be inspected to print the internal types.  

However, there are quite a few types where this just isn't possible at the moment.  For example: `map`, `set`, and `instance` types do not pass the nested type into the `schema` property of the `Struct` class, so this data isn't available after the type is created.

Additionally, type modifiers like `optional`, `nullable`, and `default` do not pass any information onto the `Struct` class, making it impossible to inspect the presence of these modifiers.

To give you an idea of what I'm trying to accomplish, here is the current code that is only partially working:
```ts
const printTS = (struct: Struct): string => {
    switch (struct.type) {
        case "array":
            return `(${printTS(struct.schema as any)})[]`
        case "enums":
            return "[" + (struct.schema as any[]).map(printTS).join(", ") + "]";
        case "union":
            return (struct.schema as any[]).map(printTS).join(" | ")
        case "literal":
            return `${struct.schema} as const`
        case "integer":
            return "number";
        case "func":
            return "(...args: any) => any"
        case "date":
            return "Date";
        case "bigint":
            return "BigInt";
        case "regexp":
            return "RegExp";
        case "number":
        case "any":
        case "never":
        case "boolean":
        case "string":
        case "unknown":
            return struct.type;
        case "object":
        case "type":
            return "{" +  Object.keys(struct.schema as any).map(s => `${s}: ${printTS((struct.schema as any)[s])}`).join(",") + "}";
        case "map": // impossible
        case "intersection": // impossible
        case "set": // impossible
        case "tuple": // impossible
        case "instance": // impossible
        break;
    }
    return ""
}
```

This pull request makes the minimal necessary changes to complete the function above and get it working for all types.