### PR TITLE
add tsc-alias for nodenext compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "np": "^10.0.0",
     "prettier": "^3.2.5",
     "rollup": "^4.12.1",
+    "tsc-alias": "^1.8.8",
     "typescript": "^4.8.3"
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,15 @@
 import { defineConfig } from 'rollup'
 import typescript from '@rollup/plugin-typescript'
-import tscAlias from 'tsc-alias';
+import tscAlias from 'tsc-alias'
 
-const tscAliasPlugin = () =>  {
-    return {
-      name: 'tscAlias',
-      async writeBundle(options) {
-        return tscAlias.replaceTscAliasPaths(options);
-      }
-    }
+const tscAliasPlugin = () => {
+  return {
+    name: 'tscAlias',
+    async writeBundle(options) {
+      return tscAlias.replaceTscAliasPaths(options)
+    },
   }
+}
 
 export default defineConfig({
   input: './src/index.ts',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,19 @@
 import { defineConfig } from 'rollup'
 import typescript from '@rollup/plugin-typescript'
+import tscAlias from 'tsc-alias';
+
+const tscAliasPlugin = () =>  {
+    return {
+      name: 'tscAlias',
+      async writeBundle(options) {
+        return tscAlias.replaceTscAliasPaths(options);
+      }
+    }
+  }
 
 export default defineConfig({
   input: './src/index.ts',
-  plugins: [typescript()],
+  plugins: [typescript(), tscAliasPlugin()],
   output: [
     {
       file: './dist/index.mjs',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,8 @@
     "strict": true,
     "suppressImplicitAnyIndexErrors": true,
     "target": "es2020"
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true
   }
 }


### PR DESCRIPTION
Use `tsc-alias` to add file extensions to type definitions for compatibility with `NodeNext`