### PR TITLE
Use Vitest and expect methods for testing suite

### DIFF
--- a/test/api/assert.test.ts
+++ b/test/api/assert.test.ts
@@ -1,38 +1,29 @@
-import { throws, doesNotThrow } from 'assert'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { assert, string, StructError } from '../../src'
 
 describe('assert', () => {
   it('valid as helper', () => {
-    doesNotThrow(() => {
-      assert('valid', string())
-    })
+    expect(() => assert('valid', string())).not.toThrow(StructError)
   })
 
   it('valid as method', () => {
-    doesNotThrow(() => {
-      // @ts-ignore
-      string().assert('valid')
-    })
+    expect(() => string().assert('valid')).not.toThrow(StructError)
   })
 
   it('invalid as helper', () => {
-    throws(() => {
-      assert(42, string())
-    }, StructError)
+    expect(() => assert(42, string())).toThrow(StructError)
   })
 
   it('invalid as method', () => {
-    throws(() => {
-      // @ts-ignore
-      string().assert(42)
-    }, StructError)
+    expect(() => string().assert(42)).toThrow(StructError)
   })
 
   it('custom error message', () => {
-    throws(() => string().assert(42, 'Not a string!'), {
-      cause: 'Expected a string, but received: 42',
-      message: 'Not a string!',
-    })
+    expect(() => string().assert(42, 'Not a string!')).toThrow(
+      expect.objectContaining({
+        cause: 'Expected a string, but received: 42',
+        message: 'Not a string!',
+      })
+    )
   })
 })

--- a/test/api/create.test.ts
+++ b/test/api/create.test.ts
@@ -1,5 +1,4 @@
-import { strictEqual, deepEqual, deepStrictEqual, throws } from 'assert'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   type,
   optional,
@@ -13,22 +12,22 @@ import {
 describe('create', () => {
   it('missing as helper', () => {
     const S = defaulted(string(), 'default')
-    strictEqual(create(undefined, S), 'default')
+    expect(create(undefined, S)).toBe('default')
   })
 
   it('missing as method', () => {
     const S = defaulted(string(), 'default')
-    strictEqual(S.create(undefined), 'default')
+    expect(S.create(undefined)).toBe('default')
   })
 
   it('not missing as helper', () => {
     const S = defaulted(string(), 'default')
-    strictEqual(create('string', S), 'string')
+    expect(create('string', S)).toBe('string')
   })
 
   it('not missing as method', () => {
     const S = defaulted(string(), 'default')
-    strictEqual(S.create('string'), 'string')
+    expect(S.create('string')).toBe('string')
   })
 
   it('missing optional fields remain missing', () => {
@@ -37,7 +36,7 @@ describe('create', () => {
       b: optional(string()),
       c: optional(type({ d: string() })),
     })
-    deepEqual(S.create({ a: 'a' }), { a: 'a' })
+    expect(S.create({ a: 'a' })).toStrictEqual({ a: 'a' })
   })
 
   it('explicit undefined values are kept', () => {
@@ -46,7 +45,7 @@ describe('create', () => {
       b: coerce(optional(string()), literal(null), () => undefined),
       c: optional(type({ d: string() })),
     })
-    deepStrictEqual(S.create({ a: 'a', b: null, c: undefined }), {
+    expect(S.create({ a: 'a', b: null, c: undefined })).toStrictEqual({
       a: 'a',
       b: undefined,
       c: undefined,
@@ -54,9 +53,11 @@ describe('create', () => {
   })
 
   it('custom error message', () => {
-    throws(() => string().create(42, 'Not a string!'), {
-      cause: 'Expected a string, but received: 42',
-      message: 'Not a string!',
-    })
+    expect(() => string().create(42, 'Not a string!')).toThrow(
+      expect.objectContaining({
+        cause: 'Expected a string, but received: 42',
+        message: 'Not a string!',
+      })
+    )
   })
 })

--- a/test/api/is.test.ts
+++ b/test/api/is.test.ts
@@ -1,21 +1,20 @@
-import { strictEqual } from 'assert'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { is, string } from '../../src'
 
 describe('is', () => {
   it('valid as helper', () => {
-    strictEqual(is('valid', string()), true)
+    expect(is('valid', string())).toBe(true)
   })
 
   it('valid as method', () => {
-    strictEqual(string().is('valid'), true)
+    expect(string().is('valid')).toBe(true)
   })
 
   it('invalid as helper', () => {
-    strictEqual(is(42, string()), false)
+    expect(is(42, string())).toBe(false)
   })
 
   it('invalid as method', () => {
-    strictEqual(string().is(42), false)
+    expect(string().is(42)).toBe(false)
   })
 })

--- a/test/api/mask.test.ts
+++ b/test/api/mask.test.ts
@@ -1,5 +1,4 @@
-import { deepStrictEqual, throws } from 'assert'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   mask,
   object,
@@ -14,21 +13,19 @@ describe('mask', () => {
   it('object as helper', () => {
     const S = object({ id: string() })
     const value = { id: '1', unknown: true }
-    deepStrictEqual(mask(value, S), { id: '1' })
+    expect(mask(value, S)).toStrictEqual({ id: '1' })
   })
 
   it('non-object as helper', () => {
     const S = object({ id: string() })
     const value = 'invalid'
-    throws(() => {
-      mask(value, S)
-    }, StructError)
+    expect(() => mask(value, S)).toThrow(StructError)
   })
 
   it('coercing', () => {
     const S = defaulted(object({ id: string() }), { id: '0' })
     const value = { unknown: true }
-    deepStrictEqual(mask(value, S), { id: '0' })
+    expect(mask(value, S)).toStrictEqual({ id: '0' })
   })
 
   it('deep masking of objects', () => {
@@ -41,7 +38,7 @@ describe('mask', () => {
       unknown: true,
       sub: [{ prop: '2', unknown: true }],
     }
-    deepStrictEqual(mask(value, S), { id: '1', sub: [{ prop: '2' }] })
+    expect(mask(value, S)).toStrictEqual({ id: '1', sub: [{ prop: '2' }] })
   })
 
   it('masking of a nested type', () => {
@@ -54,7 +51,7 @@ describe('mask', () => {
       unknown: true,
       sub: [{ prop: '2', unknown: true }],
     }
-    deepStrictEqual(mask(value, S), {
+    expect(mask(value, S)).toStrictEqual({
       id: '1',
       sub: [{ prop: '2', unknown: true }],
     })
@@ -70,7 +67,7 @@ describe('mask', () => {
       unknown: true,
       sub: [{ prop: '2', unknown: true }],
     }
-    deepStrictEqual(mask(value, S), {
+    expect(mask(value, S)).toStrictEqual({
       id: '1',
       unknown: true,
       sub: [{ prop: '2' }],
@@ -80,14 +77,16 @@ describe('mask', () => {
   it('masking does not change the original value', () => {
     const S = object({ id: string() })
     const value = { id: '1', unknown: true }
-    deepStrictEqual(mask(value, S), { id: '1' })
-    deepStrictEqual(value, { id: '1', unknown: true })
+    expect(mask(value, S)).toStrictEqual({ id: '1' })
+    expect(value).toStrictEqual({ id: '1', unknown: true })
   })
 
   it('custom error message', () => {
-    throws(() => string().mask(42, 'Not a string!'), {
-      cause: 'Expected a string, but received: 42',
-      message: 'Not a string!',
-    })
+    expect(() => string().mask(42, 'Not a string!')).toThrow(
+      expect.objectContaining({
+        cause: 'Expected a string, but received: 42',
+        message: 'Not a string!',
+      })
+    )
   })
 })

--- a/test/api/validate.test.ts
+++ b/test/api/validate.test.ts
@@ -1,5 +1,4 @@
-import { deepStrictEqual, strictEqual } from 'assert'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   validate,
   string,
@@ -13,20 +12,20 @@ import {
 describe('validate', () => {
   it('valid as helper', () => {
     const S = string()
-    deepStrictEqual(validate('valid', S), [undefined, 'valid'])
+    expect(validate('valid', S)).toStrictEqual([undefined, 'valid'])
   })
 
   it('valid as method', () => {
     const S = string()
-    deepStrictEqual(S.validate('valid'), [undefined, 'valid'])
+    expect(S.validate('valid')).toStrictEqual([undefined, 'valid'])
   })
 
   it('invalid as helper', () => {
     const S = string()
     const [err, value] = validate(42, S)
-    strictEqual(value, undefined)
-    strictEqual(err instanceof StructError, true)
-    deepStrictEqual(Array.from((err as StructError).failures()), [
+    expect(value).toStrictEqual(undefined)
+    expect(err).toBeInstanceOf(StructError)
+    expect(Array.from((err as StructError).failures())).toStrictEqual([
       {
         value: 42,
         key: undefined,
@@ -43,9 +42,9 @@ describe('validate', () => {
   it('invalid as method', () => {
     const S = string()
     const [err, value] = S.validate(42)
-    strictEqual(value, undefined)
-    strictEqual(err instanceof StructError, true)
-    deepStrictEqual(Array.from((err as StructError).failures()), [
+    expect(value).toStrictEqual(undefined)
+    expect(err).toBeInstanceOf(StructError)
+    expect(Array.from((err as StructError).failures())).toStrictEqual([
       {
         value: 42,
         key: undefined,
@@ -62,8 +61,7 @@ describe('validate', () => {
   it('error message path', () => {
     const S = object({ author: object({ name: string() }) })
     const [err] = S.validate({ author: { name: 42 } })
-    strictEqual(
-      (err as StructError).message,
+    expect(err?.message).toBe(
       'At path: author.name -- Expected a string, but received: 42'
     )
   })
@@ -71,8 +69,8 @@ describe('validate', () => {
   it('custom error message', () => {
     const S = string()
     const [err] = S.validate(42, { message: 'Validation failed!' })
-    strictEqual(err?.message, 'Validation failed!')
-    strictEqual(err?.cause, 'Expected a string, but received: 42')
+    expect(err?.message).toBe('Validation failed!')
+    expect(err?.cause).toBe('Expected a string, but received: 42')
   })
 
   it('early exit', () => {
@@ -91,8 +89,8 @@ describe('validate', () => {
 
     const S = object({ a: A, b: B })
     S.validate({ a: null, b: null })
-    strictEqual(ranA, true)
-    strictEqual(ranB, false)
+    expect(ranA).toBe(true)
+    expect(ranB).toBe(false)
   })
 
   it('refiners after children', () => {
@@ -109,7 +107,7 @@ describe('validate', () => {
     })
 
     B.validate({ a: null })
-    deepStrictEqual(order, ['validator', 'refiner'])
+    expect(order).toStrictEqual(['validator', 'refiner'])
   })
 
   it('refiners even if nested refiners fail', () => {
@@ -127,7 +125,7 @@ describe('validate', () => {
     const [error] = B.validate({ a: null })
     // Collect all failures. Ensures all validation runs.
     error?.failures()
-    strictEqual(ranOuterRefiner, true)
+    expect(ranOuterRefiner).toBe(true)
   })
 
   it('skips refiners if validators return errors', () => {
@@ -145,6 +143,6 @@ describe('validate', () => {
     const [error] = B.validate({ a: null })
     // Collect all failures. Ensures all validation runs.
     error?.failures()
-    strictEqual(ranRefiner, false)
+    expect(ranRefiner).toBe(false)
   })
 })

--- a/test/deprecated.test.ts
+++ b/test/deprecated.test.ts
@@ -1,33 +1,18 @@
-import { describe, it } from 'vitest'
-import { CallTracker } from 'assert'
-import { any, assert, Context, deprecated } from '../src'
+import { describe, expect, it, vi } from 'vitest'
+import { any, assert, deprecated } from '../src'
 
 describe('deprecated', () => {
   it('does not log deprecated type if value is undefined', () => {
-    const tracker = new CallTracker()
-    const logSpy = buildSpyWithZeroCalls(tracker)
-    assert(undefined, deprecated(any(), logSpy))
-    tracker.verify()
+    const spy = vi.fn()
+    expect(spy).not.toHaveBeenCalled()
+    assert(undefined, deprecated(any(), spy))
+    expect(spy).not.toHaveBeenCalled()
   })
 
   it('logs deprecated type to passed function if value is present', () => {
-    const tracker = new CallTracker()
-    const fakeLog = (value: unknown, ctx: Context) => {}
-    const logSpy = tracker.calls(fakeLog, 1)
-    assert('present', deprecated(any(), logSpy))
-    tracker.verify()
+    const spy = vi.fn()
+    expect(spy).not.toHaveBeenCalled()
+    assert('present', deprecated(any(), spy))
+    expect(spy).toHaveBeenCalledOnce()
   })
 })
-
-/**
- * This emulates `tracker.calls(0)`.
- *
- * `CallTracker.calls` doesn't support passing `0`, therefore we expect it
- * to be called once which is our call in this test. This proves that
- * the following action didn't call it.
- */
-function buildSpyWithZeroCalls(tracker: CallTracker) {
-  const logSpy = tracker.calls(1)
-  logSpy()
-  return logSpy
-}

--- a/test/deprecated.test.ts
+++ b/test/deprecated.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'vitest'
+import { CallTracker } from 'assert'
+import { any, assert, Context, deprecated } from '../src'
+
+describe('deprecated', () => {
+  it('does not log deprecated type if value is undefined', () => {
+    const tracker = new CallTracker()
+    const logSpy = buildSpyWithZeroCalls(tracker)
+    assert(undefined, deprecated(any(), logSpy))
+    tracker.verify()
+  })
+
+  it('logs deprecated type to passed function if value is present', () => {
+    const tracker = new CallTracker()
+    const fakeLog = (value: unknown, ctx: Context) => {}
+    const logSpy = tracker.calls(fakeLog, 1)
+    assert('present', deprecated(any(), logSpy))
+    tracker.verify()
+  })
+})
+
+/**
+ * This emulates `tracker.calls(0)`.
+ *
+ * `CallTracker.calls` doesn't support passing `0`, therefore we expect it
+ * to be called once which is our call in this test. This proves that
+ * the following action didn't call it.
+ */
+function buildSpyWithZeroCalls(tracker: CallTracker) {
+  const logSpy = tracker.calls(1)
+  logSpy()
+  return logSpy
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,17 +1,12 @@
-import assert, { CallTracker } from 'assert'
 import fs from 'fs'
 import { pick } from 'lodash'
 import { basename, extname, resolve } from 'path'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
-  any,
   assert as assertValue,
-  Context,
   create as createValue,
-  deprecated,
   StructError,
 } from '../src'
-
 describe('superstruct', () => {
   describe('validation', () => {
     const kindsDir = resolve(__dirname, 'validation')
@@ -58,7 +53,7 @@ describe('superstruct', () => {
                 )
               }
 
-              assert.deepStrictEqual(actual, output)
+              expect(actual).toStrictEqual(output)
             } else if ('failures' in module) {
               if (!err) {
                 throw new Error(
@@ -71,8 +66,8 @@ describe('superstruct', () => {
                 .failures()
                 .map((failure) => pick(failure, ...props))
 
-              assert.deepStrictEqual(actualFailures, failures)
-              assert.deepStrictEqual(pick(err, ...props), failures[0])
+              expect(actualFailures).toStrictEqual(failures)
+              expect(pick(err, ...props)).toStrictEqual(failures[0])
             } else {
               throw new Error(
                 `The "${name}" fixture did not define an \`output\` or \`failures\` export.`
@@ -83,34 +78,4 @@ describe('superstruct', () => {
       })
     }
   })
-
-  describe('deprecated', () => {
-    it('does not log deprecated type if value is undefined', () => {
-      const tracker = new CallTracker()
-      const logSpy = buildSpyWithZeroCalls(tracker)
-      assertValue(undefined, deprecated(any(), logSpy))
-      tracker.verify()
-    })
-
-    it('logs deprecated type to passed function if value is present', () => {
-      const tracker = new CallTracker()
-      const fakeLog = (value: unknown, ctx: Context) => {}
-      const logSpy = tracker.calls(fakeLog, 1)
-      assertValue('present', deprecated(any(), logSpy))
-      tracker.verify()
-    })
-  })
 })
-
-/**
- * This emulates `tracker.calls(0)`.
- *
- * `CallTracker.calls` doesn't support passing `0`, therefore we expect it
- * to be called once which is our call in this test. This proves that
- * the following action didn't call it.
- */
-function buildSpyWithZeroCalls(tracker: CallTracker) {
-  const logSpy = tracker.calls(1)
-  logSpy()
-  return logSpy
-}


### PR DESCRIPTION
In this PR, the test suite has been modified:
- `deepStrictEqual` and `deepEqual` have been changed to `.toStrictEqual` for objects and arrays and `.toBe` for literals.
- Moved the deprecated tests to their own file.
- I've opted to keep the usage of `throws` and `doesNotThrow` because it offers a nicer api to check whether an error was thrown or not than the Jesty `expect` solution.
- [Expect documentation from Vitest](https://vitest.dev/api/expect.html) for your reference!

#1244 