### PR TITLE
Remove "is-email" from testing suite

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+To run the examples locally, first run `npm install` in this directory. Then use node to run any of the examples like so: `node basic-validation.js`, `node composing-structs.js`, etc.

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,10 @@
+{
+  "type": "module",
+  "license": "MIT",
+  "dependencies": {
+    "is-email": "^1.0.2",
+    "is-url": "^1.2.4",
+    "is-uuid": "^1.0.2",
+    "superstruct": "latest"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "is-email": "^1.0.0",
     "is-url": "^1.2.4",
     "is-uuid": "^1.0.2",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "is-url": "^1.2.4",
-    "is-uuid": "^1.0.2",
     "lodash": "^4.17.15",
     "np": "^10.0.0",
     "prettier": "^3.2.5",

--- a/test/@types/is-email.d.ts
+++ b/test/@types/is-email.d.ts
@@ -1,3 +1,0 @@
-declare module 'is-email' {
-  export default function isEmail(value: any): boolean
-}

--- a/test/validation/refine/invalid.ts
+++ b/test/validation/refine/invalid.ts
@@ -1,7 +1,6 @@
-import isEmail from 'is-email'
 import { string, refine } from '../../../src'
 
-export const Struct = refine(string(), 'email', isEmail)
+export const Struct = refine(string(), 'email', (value) => value.includes('@'))
 
 export const data = 'invalid'
 

--- a/test/validation/refine/valid.ts
+++ b/test/validation/refine/valid.ts
@@ -1,7 +1,6 @@
-import isEmail from 'is-email'
 import { string, refine } from '../../../src'
 
-export const Struct = refine(string(), 'email', isEmail)
+export const Struct = refine(string(), 'email', (value) => value.includes('@'))
 
 export const data = 'name@example.com'
 


### PR DESCRIPTION
Removing `is-email` from the testing suite. Its used as a dev dependency only when testing `refine`, and it creates some complexity because we need to type that function. Not worth it in my opinion!

Related: #1244 