### PR TITLE
Generate code coverage reports and upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,23 @@ jobs:
       - run: npm install && npm test && npm run lint
         env:
           CI: true
+
+  codecov:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install deps
+        run: npm install
+
+      - name: Generate coverage report
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 npm-debug.log
 package-lock.json
 tmp/
+coverage/

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^18.7.14",
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
+    "@vitest/coverage-istanbul": "^1.6.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
@@ -54,6 +55,7 @@
     "test": "npm run build && npm run test:types && npm run test:vitest",
     "test:types": "tsc --noEmit && tsc --project ./test/tsconfig.json --noEmit",
     "test:vitest": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "watch": "npm run build -- --watch"
   },
   "keywords": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      enabled: true,
+      include: ['src'],
+      provider: 'istanbul',
+      reporter: ['cobertura'],
+    },
+  },
+})


### PR DESCRIPTION
This PR contains the changes to CI needed to generate a code coverage report and upload that code coverage report to Codecov.

This will require setting up a Codecov account for this project and adding the secret as a repository secret.

Afterwards, we can add the badge to the Readme which will display our code coverage

Part of #1244 