### PR TITLE
Allow users to run the testing suite in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test": "npm run build && npm run test:types && npm run test:vitest",
     "test:types": "tsc --noEmit && tsc --project ./test/tsconfig.json --noEmit",
     "test:vitest": "vitest run",
+    "test:watch": "vitest",
     "watch": "npm run build -- --watch"
   },
   "keywords": [


### PR DESCRIPTION
Related: #1244

Adding a script to `package.json` to allow the testing suite to be run in watch mode. It will automatically re-run the testing suite when a file is updated.