### PR TITLE
Fix UMD Build `.cjs` Extension Blocked Due to Incorrect MIME Type

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/superstruct.git",
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
       sourcemap: true,
     },
     {
-      file: './dist/index.cjs',
+      file: './dist/index.js',
       format: 'umd',
       name: 'Superstruct',
       sourcemap: true,


### PR DESCRIPTION
## Overview

Some browsers enforce strict Content Security Policy (CSP) or Cross-Origin Read Blocking (CORB) rules that check the MIME type of scripts. If the MIME type returned in the response headers doesn’t match the expected type for execution, the browser will block the script.

### Example: JSDelivr

For instance, if you use the following snippet:

```html
<script src="https://cdn.jsdelivr.net/npm/superstruct"></script>
```

JSDelivr will serve the script with a MIME type of `application/node`, which causes the browser to block it:

<img width="592" alt="Image" src="https://github.com/user-attachments/assets/435124a0-60dd-4274-a13b-5595761442c4" />

### Example: Unpkg

For instance, if you use the following snippet:

```html
<script src="https://unpkg.com/superstruct"></script>
```

Unpkg will serve the script with a MIME type of `text/plain`, which will also result in the script being blocked:

<img width="592" alt="Image" src="https://github.com/user-attachments/assets/a0c64a05-8ac5-4a84-a2a3-3960d19281e8" />

## Suggested Fix

To resolve this issue, we recommend using the `.js` extension instead of `.cjs`. Changing the extension to `.js` when bundling will ensure proper execution of the script.

This change will help avoid MIME type mismatches and prevent browsers from blocking the script.